### PR TITLE
SimpleModalBorder: add modal action

### DIFF
--- a/demo/src/main/java/raven/modal/demo/simple/SimpleInputForms.java
+++ b/demo/src/main/java/raven/modal/demo/simple/SimpleInputForms.java
@@ -2,8 +2,12 @@ package raven.modal.demo.simple;
 
 import com.formdev.flatlaf.FlatClientProperties;
 import net.miginfocom.swing.MigLayout;
+import raven.modal.component.ModalBorderAction;
+import raven.modal.component.SimpleModalBorder;
 
 import javax.swing.*;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
 
 public class SimpleInputForms extends JPanel {
 
@@ -46,6 +50,18 @@ public class SimpleInputForms extends JPanel {
 
         add(new JLabel("Address"), "gapy 5 0");
         add(scroll, "height 150,grow,pushy");
+
+        txtAddress.addKeyListener(new KeyAdapter() {
+            @Override
+            public void keyTyped(KeyEvent e) {
+                if (e.isControlDown() && e.getKeyChar() == 10) {
+                    ModalBorderAction modalBorderAction = ModalBorderAction.getModalBorderAction(SimpleInputForms.this);
+                    if (modalBorderAction != null) {
+                        modalBorderAction.doAction(SimpleModalBorder.YES_OPTION);
+                    }
+                }
+            }
+        });
         initComboItem(comboCountry);
     }
 

--- a/modal-dialog/src/main/java/raven/modal/component/ModalBorderAction.java
+++ b/modal-dialog/src/main/java/raven/modal/component/ModalBorderAction.java
@@ -1,0 +1,22 @@
+package raven.modal.component;
+
+import java.awt.*;
+
+/**
+ * @author Raven
+ */
+public interface ModalBorderAction {
+
+    void doAction(int action);
+
+
+    public static ModalBorderAction getModalBorderAction(Component com) {
+        if (com == null) {
+            return null;
+        }
+        if (com instanceof ModalBorderAction) {
+            return (ModalBorderAction) com;
+        }
+        return getModalBorderAction(com.getParent());
+    }
+}

--- a/modal-dialog/src/main/java/raven/modal/component/SimpleModalBorder.java
+++ b/modal-dialog/src/main/java/raven/modal/component/SimpleModalBorder.java
@@ -17,7 +17,7 @@ import java.util.function.Consumer;
  *
  * @author Raven
  */
-public class SimpleModalBorder extends Modal {
+public class SimpleModalBorder extends Modal implements ModalBorderAction {
 
     private final Component component;
     private final ModalBorderOption option;
@@ -211,7 +211,8 @@ public class SimpleModalBorder extends Modal {
         };
     }
 
-    private void doAction(int action) {
+    @Override
+    public void doAction(int action) {
         if (callback == null) {
             getController().getModalContainer().closeModal();
         } else {


### PR DESCRIPTION
Add modal action.
So we can call modal to do action like `CLOSE_OPTION` or `YES_OPTION` etc.

Example:
```java
ModalBorderAction modalBorderAction = ModalBorderAction.getModalBorderAction(this);
if (modalBorderAction != null) {
    modalBorderAction.doAction(SimpleModalBorder.YES_OPTION);
}
```
`this` is child component inside the modal component