### PR TITLE
Demo: add custom modal message

### DIFF
--- a/demo/src/main/java/raven/modal/demo/forms/FormModal.java
+++ b/demo/src/main/java/raven/modal/demo/forms/FormModal.java
@@ -6,6 +6,7 @@ import raven.modal.ModalDialog;
 import raven.modal.component.SimpleModalBorder;
 import raven.modal.demo.component.LabelButton;
 import raven.modal.demo.simple.SimpleInputForms;
+import raven.modal.demo.simple.SimpleMessageModal;
 import raven.modal.demo.system.Form;
 import raven.modal.option.Location;
 import raven.modal.option.Option;
@@ -48,6 +49,7 @@ public class FormModal extends Form {
         panel.add(createModalOptions());
         panel.add(createModalOptionsClickType());
         panel.add(createSampleModal(), "span 2");
+        panel.add(createCustomModal(), "span 2");
         return panel;
     }
 
@@ -150,6 +152,30 @@ public class FormModal extends Form {
         return panel;
     }
 
+    private Component createCustomModal() {
+        JPanel panel = new JPanel(new MigLayout());
+        panel.setBorder(new TitledBorder("Custom message modal"));
+
+        LabelButton lbDefault = new LabelButton("Show default");
+        LabelButton lbSuccess = new LabelButton("Show success");
+        LabelButton lbInfo = new LabelButton("Show info");
+        LabelButton lbWarning = new LabelButton("Show warning");
+        LabelButton lbError = new LabelButton("Show error");
+
+        lbDefault.addOnClick(o -> showCustomModal(SimpleMessageModal.Type.DEFAULT, getSelectedOption()));
+        lbSuccess.addOnClick(o -> showCustomModal(SimpleMessageModal.Type.SUCCESS, getSelectedOption()));
+        lbInfo.addOnClick(o -> showCustomModal(SimpleMessageModal.Type.INFO, getSelectedOption()));
+        lbWarning.addOnClick(o -> showCustomModal(SimpleMessageModal.Type.WARNING, getSelectedOption()));
+        lbError.addOnClick(o -> showCustomModal(SimpleMessageModal.Type.ERROR, getSelectedOption()));
+
+        panel.add(lbDefault);
+        panel.add(lbSuccess);
+        panel.add(lbInfo);
+        panel.add(lbWarning);
+        panel.add(lbError);
+        return panel;
+    }
+
     private void showModal(Option option) {
         JTextArea txt = new JTextArea();
         txt.setEditable(false);
@@ -158,6 +184,16 @@ public class FormModal extends Form {
         txt.setText("Sets the default hide mode for the layout. This hide mode can be overridden by the component constraint." +
                 "\nThe hide mode specified how the layout manager should handle a component that isn't visible.");
         ModalDialog.showModal(this, new SimpleModalBorder(txt, "Sample Message", SimpleModalBorder.YES_NO_OPTION, null), option);
+    }
+
+    private void showCustomModal(SimpleMessageModal.Type type, Option option) {
+        String message = "Hello! I hope you're having a wonderful day." +
+                "\nI wanted to take a moment to check in and see how you're doing." +
+                "\nWhether you've been working on any exciting projects," +
+                "\nencountered any interesting challenges," +
+                "\nor simply had a good time relaxing, I'd love to hear about it." +
+                "\nIt's always great to catch up and share our experiences.";
+        ModalDialog.showModal(this, new SimpleMessageModal(type, message, "This is a modal custom message", SimpleModalBorder.YES_NO_OPTION, null), option);
     }
 
     private void showModalSlide(Option option) {

--- a/demo/src/main/java/raven/modal/demo/simple/SimpleMessageModal.java
+++ b/demo/src/main/java/raven/modal/demo/simple/SimpleMessageModal.java
@@ -1,0 +1,139 @@
+package raven.modal.demo.simple;
+
+import com.formdev.flatlaf.FlatClientProperties;
+import com.formdev.flatlaf.extras.FlatSVGIcon;
+import net.miginfocom.swing.MigLayout;
+import raven.modal.Toast;
+import raven.modal.component.SimpleModalBorder;
+import raven.modal.listener.ModalCallback;
+import raven.modal.toast.ToastPanel;
+
+import javax.swing.*;
+import java.awt.*;
+
+public class SimpleMessageModal extends SimpleModalBorder {
+
+    private final Type type;
+
+    public SimpleMessageModal(Type type, String message, String title, int optionType, ModalCallback callback) {
+        super(createMessage(type, message), title, optionType, callback);
+        this.type = type;
+    }
+
+    private static Component createMessage(Type type, String message) {
+        JTextArea text = new JTextArea(message);
+        text.setWrapStyleWord(true);
+        text.setFocusable(false);
+        text.setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
+        String gap = type == Type.DEFAULT ? "35" : "67";
+        text.putClientProperty(FlatClientProperties.STYLE, "" +
+                "border:0," + gap + ",10,35;" +
+                "background:null;" +
+                "[light]foreground:lighten($Label.foreground,20%);" +
+                "[dark]foreground:darken($Label.foreground,20%);");
+        return text;
+    }
+
+    @Override
+    protected JComponent createTitleComponent(String title) {
+        if (type == Type.DEFAULT) {
+            return super.createTitleComponent(title);
+        }
+        Icon icon = createIcon(type);
+        JLabel label = (JLabel) super.createTitleComponent(title);
+        label.setIconTextGap(10);
+        label.setIcon(icon);
+        return label;
+    }
+
+    @Override
+    protected JComponent createOptionButton(Option[] optionsType) {
+        JPanel panel = (JPanel) super.createOptionButton(optionsType);
+        // modify layout option
+        if (panel.getLayout() instanceof MigLayout) {
+            MigLayout layout = (MigLayout) panel.getLayout();
+            layout.setColumnConstraints("[]12[]");
+        }
+
+        // revers order
+        Component[] components = panel.getComponents();
+        panel.removeAll();
+        for (int i = components.length - 1; i >= 0; i--) {
+            panel.add(components[i]);
+        }
+        return panel;
+    }
+
+    @Override
+    protected JButton createButtonOption(Option option) {
+        JButton button = super.createButtonOption(option);
+        String colors[] = getColorKey(type);
+        if (button.isDefaultButton()) {
+            button.putClientProperty(FlatClientProperties.STYLE, "" +
+                    "arc:999;" +
+                    "margin:3,33,3,33;" +
+                    "borderWidth:0;" +
+                    "focusWidth:0;" +
+                    "innerFocusWidth:0;" +
+                    "default.borderWidth:0;" +
+                    "[light]background:" + colors[0] + ";" +
+                    "[dark]background:" + colors[1] + ";");
+        } else {
+            button.putClientProperty(FlatClientProperties.STYLE, "" +
+                    "arc:999;" +
+                    "margin:3,33,3,33;" +
+                    "borderWidth:1;" +
+                    "focusWidth:0;" +
+                    "innerFocusWidth:1;" +
+                    "background:null;" +
+                    "[light]borderColor:" + colors[0] + ";" +
+                    "[dark]borderColor:" + colors[1] + ";" +
+                    "[light]focusedBorderColor:" + colors[0] + ";" +
+                    "[dark]focusedBorderColor:" + colors[1] + ";" +
+                    "[light]focusColor:" + colors[0] + ";" +
+                    "[dark]focusColor:" + colors[1] + ";" +
+                    "[light]hoverBorderColor:" + colors[0] + ";" +
+                    "[dark]hoverBorderColor:" + colors[1] + ";" +
+                    "[light]foreground:" + colors[0] + ";" +
+                    "[dark]foreground:" + colors[1] + ";");
+        }
+        return button;
+    }
+
+    protected Icon createIcon(Type type) {
+        ToastPanel.ThemesData data = Toast.getThemesData().get(asToastType(type));
+        FlatSVGIcon icon = new FlatSVGIcon(data.getIcon(), 0.45f);
+        FlatSVGIcon.ColorFilter colorFilter = new FlatSVGIcon.ColorFilter();
+        colorFilter.add(Color.decode("#969696"), Color.decode(data.getColors()[0]), Color.decode(data.getColors()[1]));
+        icon.setColorFilter(colorFilter);
+        return icon;
+    }
+
+    protected String[] getColorKey(Type type) {
+        if (type == Type.DEFAULT) {
+            // use accent color as default type
+            return new String[]{"$Component.accentColor", "$Component.accentColor"};
+        }
+        ToastPanel.ThemesData data = Toast.getThemesData().get(asToastType(type));
+        return data.getColors();
+    }
+
+    private Toast.Type asToastType(Type type) {
+        switch (type) {
+            case DEFAULT:
+                return Toast.Type.DEFAULT;
+            case SUCCESS:
+                return Toast.Type.SUCCESS;
+            case INFO:
+                return Toast.Type.INFO;
+            case WARNING:
+                return Toast.Type.WARNING;
+            default:
+                return Toast.Type.ERROR;
+        }
+    }
+
+    public enum Type {
+        DEFAULT, SUCCESS, INFO, WARNING, ERROR
+    }
+}


### PR DESCRIPTION
This RP update demo project by added custom simple message model

### Example
``` java
ModalDialog.showModal(this, new SimpleMessageModal(
                SimpleMessageModal.Type.SUCCESS,
                message,
                "This is a modal custom message",
                SimpleModalBorder.YES_NO_OPTION,
                callback)
        , option);
```
### This custom message has 5 type
``` java
public enum Type {
    DEFAULT, SUCCESS, INFO, WARNING, ERROR
}
```

#### Simple message

<img src="https://github.com/DJ-Raven/swing-modal-dialog/assets/58245926/a794f180-739b-4e6b-8cf2-ca9f658b013d" alt="simple 1"/>

#### Form modal updated

<img src="https://github.com/DJ-Raven/swing-modal-dialog/assets/58245926/4a33c4d8-bbc6-436f-93d1-d9ca2e9205af" alt="simple 2" width="537"/>