### PR TITLE
Demo: add quick form search

### DIFF
--- a/demo/src/main/java/raven/modal/demo/component/EmptyModalBorder.java
+++ b/demo/src/main/java/raven/modal/demo/component/EmptyModalBorder.java
@@ -1,0 +1,14 @@
+package raven.modal.demo.component;
+
+import net.miginfocom.swing.MigLayout;
+import raven.modal.component.Modal;
+
+import java.awt.*;
+
+public class EmptyModalBorder extends Modal {
+
+    public EmptyModalBorder(Component component) {
+        setLayout(new MigLayout("fill,insets 0", "[fill]", "[fill]"));
+        add(component);
+    }
+}

--- a/demo/src/main/java/raven/modal/demo/component/FormSearchButton.java
+++ b/demo/src/main/java/raven/modal/demo/component/FormSearchButton.java
@@ -1,0 +1,32 @@
+package raven.modal.demo.component;
+
+import com.formdev.flatlaf.FlatClientProperties;
+import com.formdev.flatlaf.extras.FlatSVGIcon;
+import net.miginfocom.swing.MigLayout;
+
+import javax.swing.*;
+
+public class FormSearchButton extends JButton {
+
+    public FormSearchButton() {
+        super("Quick Search...", new FlatSVGIcon("raven/modal/demo/icons/search.svg", 0.4f));
+        init();
+    }
+
+    private void init() {
+        setLayout(new MigLayout("insets 0,al trailing,filly", "", "[center]"));
+        setHorizontalAlignment(JButton.LEADING);
+        putClientProperty(FlatClientProperties.STYLE, "" +
+                "margin:3,7,3,10;" +
+                "background:$TextField.background;" +
+                "arc:999;" +
+                "borderWidth:1;" +
+                "focusWidth:0;" +
+                "innerFocusWidth:0;" +
+                "foreground:$TextField.placeholderForeground;");
+        JLabel label = new JLabel("Ctrl F");
+        label.putClientProperty(FlatClientProperties.STYLE, "" +
+                "foreground:$Label.disabledForeground;");
+        add(label);
+    }
+}

--- a/demo/src/main/java/raven/modal/demo/component/FormSearchPanel.java
+++ b/demo/src/main/java/raven/modal/demo/component/FormSearchPanel.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 public class FormSearchPanel extends JPanel {
 
+    private LookAndFeel oldTheme = UIManager.getLookAndFeel();
     private final Map<SystemForm, Class<? extends Form>> formsMap;
 
     public FormSearchPanel(Map<SystemForm, Class<? extends Form>> formsMap) {
@@ -61,6 +62,13 @@ public class FormSearchPanel extends JPanel {
         }
         add(scrollPane);
         installSearchField();
+    }
+
+    public final void formCheck() {
+        if (oldTheme != UIManager.getLookAndFeel()) {
+            oldTheme = UIManager.getLookAndFeel();
+            SwingUtilities.updateComponentTreeUI(this);
+        }
     }
 
     private void installSearchField() {
@@ -144,6 +152,9 @@ public class FormSearchPanel extends JPanel {
         for (int i = 0; i < components.length; i++) {
             if (components[i] instanceof JButton) {
                 ((JButton) components[i]).setSelected(index == i);
+                if (i == index) {
+                    panelResult.scrollRectToVisible(components[i].getBounds());
+                }
             }
         }
     }
@@ -228,7 +239,8 @@ public class FormSearchPanel extends JPanel {
                     "arc:10;" +
                     "borderWidth:0;" +
                     "focusWidth:0;" +
-                    "innerFocusWidth:0;");
+                    "innerFocusWidth:0;" +
+                    "[light]selectedBackground:lighten($Button.selectedBackground,9%)");
             JLabel labelDescription = new JLabel(data.description());
             labelDescription.putClientProperty(FlatClientProperties.STYLE, "" +
                     "foreground:$Label.disabledForeground;");

--- a/demo/src/main/java/raven/modal/demo/component/FormSearchPanel.java
+++ b/demo/src/main/java/raven/modal/demo/component/FormSearchPanel.java
@@ -1,0 +1,71 @@
+package raven.modal.demo.component;
+
+import com.formdev.flatlaf.FlatClientProperties;
+import com.formdev.flatlaf.extras.FlatSVGIcon;
+import com.formdev.flatlaf.icons.FlatMenuArrowIcon;
+import net.miginfocom.swing.MigLayout;
+import raven.modal.demo.layout.ResponsiveLayout;
+
+import javax.swing.*;
+import java.awt.*;
+
+public class FormSearchPanel extends JPanel {
+
+    public FormSearchPanel() {
+        init();
+    }
+
+    private void init() {
+        setLayout(new MigLayout("fillx,insets 0,wrap", "[fill,500]"));
+        textSearch = new JTextField();
+        panelResult = new JPanel(new ResponsiveLayout(ResponsiveLayout.JustifyContent.FIT_CONTENT, new Dimension(-1, -1), 10, 0, 1));
+        panelResult.putClientProperty(FlatClientProperties.STYLE, "" +
+                "border:0,10,0,10;");
+        textSearch.putClientProperty(FlatClientProperties.PLACEHOLDER_TEXT, "Search...");
+        textSearch.putClientProperty(FlatClientProperties.TEXT_FIELD_LEADING_ICON, new FlatSVGIcon("raven/modal/demo/icons/search.svg", 0.4f));
+        textSearch.putClientProperty(FlatClientProperties.STYLE, "" +
+                "border:3,20,3,20;" +
+                "background:null;");
+        add(textSearch);
+        add(new JSeparator(), "height 2");
+        JScrollPane scrollPane = new JScrollPane(panelResult);
+        scrollPane.setBorder(BorderFactory.createEmptyBorder());
+        scrollPane.getVerticalScrollBar().setUnitIncrement(10);
+        panelResult.add(new Item("Test 1"));
+        panelResult.add(new Item("Test 2"));
+        panelResult.add(new Item("Test 3"));
+        panelResult.add(new Item("Test 4"));
+
+        add(scrollPane);
+    }
+
+    private JTextField textSearch;
+    private JPanel panelResult;
+
+    private static class Item extends JButton {
+
+        private String text;
+
+        public Item(String text) {
+            this.text = text;
+            init();
+        }
+
+        private void init() {
+            setHorizontalAlignment(JButton.LEADING);
+            setLayout(new MigLayout("insets 3 3 3 0,filly,gapy 2", "[]push[]"));
+            putClientProperty(FlatClientProperties.STYLE, "" +
+                    "background:null;" +
+                    "arc:10;" +
+                    "borderWidth:0;" +
+                    "focusWidth:0;" +
+                    "innerFocusWidth:0;");
+            JLabel labelDescription = new JLabel("description");
+            labelDescription.putClientProperty(FlatClientProperties.STYLE, "" +
+                    "foreground:$Label.disabledForeground;");
+            add(new JLabel(text), "cell 0 0");
+            add(labelDescription, "cell 0 1");
+            add(new JLabel(new FlatMenuArrowIcon()), "cell 1 0,span 1 2");
+        }
+    }
+}

--- a/demo/src/main/java/raven/modal/demo/component/FormSearchPanel.java
+++ b/demo/src/main/java/raven/modal/demo/component/FormSearchPanel.java
@@ -31,19 +31,21 @@ public class FormSearchPanel extends JPanel {
     private void init() {
         setLayout(new MigLayout("fillx,insets 0,wrap", "[fill,500]"));
         textSearch = new JTextField();
-        panelResult = new JPanel(new ResponsiveLayout(ResponsiveLayout.JustifyContent.FIT_CONTENT, new Dimension(-1, -1), 10, 0, 1));
+        panelResult = new JPanel(new ResponsiveLayout(ResponsiveLayout.JustifyContent.FIT_CONTENT, new Dimension(-1, -1), 10, 3, 1));
         panelResult.putClientProperty(FlatClientProperties.STYLE, "" +
                 "border:0,10,0,10;");
         textSearch.putClientProperty(FlatClientProperties.PLACEHOLDER_TEXT, "Search...");
         textSearch.putClientProperty(FlatClientProperties.TEXT_FIELD_LEADING_ICON, new FlatSVGIcon("raven/modal/demo/icons/search.svg", 0.4f));
         textSearch.putClientProperty(FlatClientProperties.STYLE, "" +
-                "border:3,20,3,20;" +
-                "background:null;");
-        add(textSearch);
+                "border:3,3,3,3;" +
+                "background:null;" +
+                "showClearButton:true;");
+        add(textSearch, "gap 17 17 0 0");
         add(new JSeparator(), "height 2!");
         JScrollPane scrollPane = new JScrollPane(panelResult);
         scrollPane.setBorder(BorderFactory.createEmptyBorder());
         scrollPane.getVerticalScrollBar().setUnitIncrement(10);
+        scrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
         for (Map.Entry<SystemForm, Class<? extends Form>> entry : formsMap.entrySet()) {
             panelResult.add(new Item(entry.getKey(), entry.getValue()));
         }
@@ -88,6 +90,8 @@ public class FormSearchPanel extends JPanel {
                     }
                     if (panelResult.getComponentCount() > 0) {
                         setSelected(0);
+                    } else {
+                        panelResult.add(createNoResult(st));
                     }
                     panelResult.repaint();
                     SwingUtilities.getAncestorOfClass(ModalContainer.class, FormSearchPanel.this).revalidate();
@@ -172,6 +176,22 @@ public class FormSearchPanel extends JPanel {
                 }
             }
         }
+    }
+
+    private Component createNoResult(String text) {
+        JPanel panel = new JPanel(new MigLayout("al center,gapx 1"));
+        JLabel label = new JLabel("No result for \"");
+        JLabel labelEnd = new JLabel("\"");
+        label.putClientProperty(FlatClientProperties.STYLE, "" +
+                "foreground:$Label.disabledForeground;");
+        labelEnd.putClientProperty(FlatClientProperties.STYLE, "" +
+                "foreground:$Label.disabledForeground;");
+        JLabel labelText = new JLabel(text);
+
+        panel.add(label);
+        panel.add(labelText);
+        panel.add(labelEnd);
+        return panel;
     }
 
     private JTextField textSearch;

--- a/demo/src/main/java/raven/modal/demo/component/FormSearchPanel.java
+++ b/demo/src/main/java/raven/modal/demo/component/FormSearchPanel.java
@@ -46,6 +46,13 @@ public class FormSearchPanel extends JPanel {
         scrollPane.setBorder(BorderFactory.createEmptyBorder());
         scrollPane.getVerticalScrollBar().setUnitIncrement(10);
         scrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
+
+        scrollPane.getVerticalScrollBar().putClientProperty(FlatClientProperties.STYLE, "" +
+                "trackArc:$ScrollBar.thumbArc;" +
+                "thumbInsets:0,3,0,3;" +
+                "trackInsets:0,3,0,3;" +
+                "width:12;");
+
         for (Map.Entry<SystemForm, Class<? extends Form>> entry : formsMap.entrySet()) {
             panelResult.add(new Item(entry.getKey(), entry.getValue()));
         }

--- a/demo/src/main/java/raven/modal/demo/component/FormSearchPanel.java
+++ b/demo/src/main/java/raven/modal/demo/component/FormSearchPanel.java
@@ -15,6 +15,9 @@ import raven.modal.demo.utils.SystemForm;
 import javax.swing.*;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
+import javax.swing.text.AttributeSet;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.PlainDocument;
 import java.awt.*;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
@@ -26,6 +29,7 @@ import java.util.Map;
 public class FormSearchPanel extends JPanel {
 
     private LookAndFeel oldTheme = UIManager.getLookAndFeel();
+    private final int SEARCH_MAX_LENGTH = 50;
     private final Map<SystemForm, Class<? extends Form>> formsMap;
 
     public FormSearchPanel(Map<SystemForm, Class<? extends Form>> formsMap) {
@@ -70,6 +74,14 @@ public class FormSearchPanel extends JPanel {
     }
 
     private void installSearchField() {
+        textSearch.setDocument(new PlainDocument() {
+            @Override
+            public void insertString(int offs, String str, AttributeSet a) throws BadLocationException {
+                if (getLength() + str.length() <= SEARCH_MAX_LENGTH) {
+                    super.insertString(offs, str, a);
+                }
+            }
+        });
         textSearch.getDocument().addDocumentListener(new DocumentListener() {
             private String text;
 

--- a/demo/src/main/java/raven/modal/demo/forms/FormAvatarIcon.java
+++ b/demo/src/main/java/raven/modal/demo/forms/FormAvatarIcon.java
@@ -5,11 +5,13 @@ import net.miginfocom.swing.MigLayout;
 import raven.extras.AvatarIcon;
 import raven.modal.demo.component.AvatarBorderColorIcon;
 import raven.modal.demo.system.Form;
+import raven.modal.demo.utils.SystemForm;
 
 import javax.swing.*;
 import javax.swing.border.TitledBorder;
 import java.awt.*;
 
+@SystemForm(name = "Avatar Icon", description = "avatar icon graphical element", tags = {"profile", "photo"})
 public class FormAvatarIcon extends Form {
 
     public FormAvatarIcon() {

--- a/demo/src/main/java/raven/modal/demo/forms/FormAvatarIcon.java
+++ b/demo/src/main/java/raven/modal/demo/forms/FormAvatarIcon.java
@@ -11,7 +11,7 @@ import javax.swing.*;
 import javax.swing.border.TitledBorder;
 import java.awt.*;
 
-@SystemForm(name = "Avatar Icon", description = "avatar icon graphical element", tags = {"profile", "photo"})
+@SystemForm(name = "Avatar Icon", description = "avatar icon graphical element", tags = {"profile", "photo", "image", "circle", "picture"})
 public class FormAvatarIcon extends Form {
 
     public FormAvatarIcon() {

--- a/demo/src/main/java/raven/modal/demo/forms/FormDashboard.java
+++ b/demo/src/main/java/raven/modal/demo/forms/FormDashboard.java
@@ -2,9 +2,11 @@ package raven.modal.demo.forms;
 
 import net.miginfocom.swing.MigLayout;
 import raven.modal.demo.system.Form;
+import raven.modal.demo.utils.SystemForm;
 
 import javax.swing.*;
 
+@SystemForm(name = "Dashboard", description = "dashboard form display some details")
 public class FormDashboard extends Form {
 
     public FormDashboard() {

--- a/demo/src/main/java/raven/modal/demo/forms/FormDateTime.java
+++ b/demo/src/main/java/raven/modal/demo/forms/FormDateTime.java
@@ -5,11 +5,13 @@ import net.miginfocom.swing.MigLayout;
 import raven.datetime.component.date.DatePicker;
 import raven.datetime.component.time.TimePicker;
 import raven.modal.demo.system.Form;
+import raven.modal.demo.utils.SystemForm;
 
 import javax.swing.*;
 import javax.swing.border.TitledBorder;
 import java.awt.*;
 
+@SystemForm(name = "DateTime", description = "date time picker user interface component")
 public class FormDateTime extends Form {
 
     public FormDateTime() {

--- a/demo/src/main/java/raven/modal/demo/forms/FormInput.java
+++ b/demo/src/main/java/raven/modal/demo/forms/FormInput.java
@@ -2,9 +2,11 @@ package raven.modal.demo.forms;
 
 import net.miginfocom.swing.MigLayout;
 import raven.modal.demo.system.Form;
+import raven.modal.demo.utils.SystemForm;
 
 import javax.swing.*;
 
+@SystemForm(name = "Form Input", description = "input form not yet update")
 public class FormInput extends Form {
 
     public FormInput() {

--- a/demo/src/main/java/raven/modal/demo/forms/FormModal.java
+++ b/demo/src/main/java/raven/modal/demo/forms/FormModal.java
@@ -8,6 +8,7 @@ import raven.modal.demo.component.LabelButton;
 import raven.modal.demo.simple.SimpleInputForms;
 import raven.modal.demo.simple.SimpleMessageModal;
 import raven.modal.demo.system.Form;
+import raven.modal.demo.utils.SystemForm;
 import raven.modal.option.Location;
 import raven.modal.option.Option;
 
@@ -15,6 +16,7 @@ import javax.swing.*;
 import javax.swing.border.TitledBorder;
 import java.awt.*;
 
+@SystemForm(name = "Modal", description = "modal dialog user interface element", tags = {"dialog", "popup"})
 public class FormModal extends Form {
 
     public FormModal() {

--- a/demo/src/main/java/raven/modal/demo/forms/FormResponsiveLayout.java
+++ b/demo/src/main/java/raven/modal/demo/forms/FormResponsiveLayout.java
@@ -7,12 +7,14 @@ import raven.modal.demo.layout.ResponsiveLayout;
 import raven.modal.demo.model.ModelEmployee;
 import raven.modal.demo.sample.SampleData;
 import raven.modal.demo.system.Form;
+import raven.modal.demo.utils.SystemForm;
 
 import javax.swing.*;
 import javax.swing.border.TitledBorder;
 import java.awt.*;
 import java.util.function.Consumer;
 
+@SystemForm(name = "Responsive Layout", description = "responsive layout user interface", tags = {"card"})
 public class FormResponsiveLayout extends Form {
 
     public FormResponsiveLayout() {

--- a/demo/src/main/java/raven/modal/demo/forms/FormSetting.java
+++ b/demo/src/main/java/raven/modal/demo/forms/FormSetting.java
@@ -11,6 +11,7 @@ import raven.modal.demo.component.AccentColorIcon;
 import raven.modal.demo.system.Form;
 import raven.modal.demo.system.FormManager;
 import raven.modal.demo.themes.PanelThemes;
+import raven.modal.demo.utils.SystemForm;
 import raven.modal.drawer.DrawerBuilder;
 import raven.modal.option.LayoutOption;
 import raven.modal.option.Location;
@@ -20,6 +21,7 @@ import javax.swing.border.TitledBorder;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 
+@SystemForm(name = "Setting", description = "application setting and configuration", tags = {"themes", "options"})
 public class FormSetting extends Form {
 
     public FormSetting() {

--- a/demo/src/main/java/raven/modal/demo/forms/FormTable.java
+++ b/demo/src/main/java/raven/modal/demo/forms/FormTable.java
@@ -10,6 +10,7 @@ import raven.modal.demo.model.ModelProfile;
 import raven.modal.demo.sample.SampleData;
 import raven.modal.demo.simple.SimpleInputForms;
 import raven.modal.demo.system.Form;
+import raven.modal.demo.utils.SystemForm;
 import raven.modal.demo.utils.table.CheckBoxTableHeaderRenderer;
 import raven.modal.demo.utils.table.TableHeaderAlignment;
 import raven.modal.demo.utils.table.TableProfileCellRenderer;
@@ -20,6 +21,7 @@ import javax.swing.*;
 import javax.swing.table.DefaultTableModel;
 import java.awt.*;
 
+@SystemForm(name = "Table", description = "table is a user interface component", tags = {"list"})
 public class FormTable extends Form {
 
     public FormTable() {

--- a/demo/src/main/java/raven/modal/demo/forms/FormToast.java
+++ b/demo/src/main/java/raven/modal/demo/forms/FormToast.java
@@ -6,6 +6,7 @@ import raven.modal.Toast;
 import raven.modal.demo.component.LabelButton;
 import raven.modal.demo.simple.SimpleCustomToast;
 import raven.modal.demo.system.Form;
+import raven.modal.demo.utils.SystemForm;
 import raven.modal.option.Location;
 import raven.modal.toast.option.ToastLocation;
 import raven.modal.toast.option.ToastOption;
@@ -17,6 +18,7 @@ import javax.swing.border.TitledBorder;
 import java.awt.*;
 import java.util.Random;
 
+@SystemForm(name = "Toast", description = "toast notification message", tags = {"alert"})
 public class FormToast extends Form {
 
     public FormToast() {

--- a/demo/src/main/java/raven/modal/demo/menu/MyDrawerBuilder.java
+++ b/demo/src/main/java/raven/modal/demo/menu/MyDrawerBuilder.java
@@ -1,6 +1,7 @@
 package raven.modal.demo.menu;
 
 import com.formdev.flatlaf.FlatClientProperties;
+import raven.modal.demo.forms.*;
 import raven.modal.demo.system.AllForms;
 import raven.modal.demo.system.FormManager;
 import raven.modal.drawer.DrawerPanel;
@@ -105,9 +106,9 @@ public class MyDrawerBuilder extends SimpleDrawerBuilder {
                 if (index.length == 1) {
                     int i = index[0];
                     if (i == 0) {
-                        FormManager.showForm(AllForms.getFormDashboard());
+                        FormManager.showForm(AllForms.getForm(FormDashboard.class));
                     } else if (i == 7) {
-                        FormManager.showForm(AllForms.getFormSetting());
+                        FormManager.showForm(AllForms.getForm(FormSetting.class));
                     } else if (i == 8) {
                         FormManager.logout();
                     }
@@ -116,21 +117,21 @@ public class MyDrawerBuilder extends SimpleDrawerBuilder {
                     int j = index[1];
                     if (i == 1) {
                         if (j == 0) {
-                            FormManager.showForm(AllForms.getFormInput());
+                            FormManager.showForm(AllForms.getForm(FormInput.class));
                         } else if (j == 1) {
-                            FormManager.showForm(AllForms.getFormTable());
+                            FormManager.showForm(AllForms.getForm(FormTable.class));
                         } else if (j == 2) {
-                            FormManager.showForm(AllForms.getFormResponsiveLayout());
+                            FormManager.showForm(AllForms.getForm(FormResponsiveLayout.class));
                         }
                     } else if (i == 2) {
                         if (j == 0) {
-                            FormManager.showForm(AllForms.getFormModal());
+                            FormManager.showForm(AllForms.getForm(FormModal.class));
                         } else if (j == 1) {
-                            FormManager.showForm(AllForms.getFormToast());
+                            FormManager.showForm(AllForms.getForm(FormToast.class));
                         } else if (j == 2) {
-                            FormManager.showForm(AllForms.getFormDateTime());
+                            FormManager.showForm(AllForms.getForm(FormDateTime.class));
                         } else if (j == 3) {
-                            FormManager.showForm(AllForms.getFormAvatarIcon());
+                            FormManager.showForm(AllForms.getForm(FormAvatarIcon.class));
                         }
                     }
                 }

--- a/demo/src/main/java/raven/modal/demo/system/AllForms.java
+++ b/demo/src/main/java/raven/modal/demo/system/AllForms.java
@@ -1,22 +1,15 @@
 package raven.modal.demo.system;
 
-import raven.modal.demo.forms.*;
-
 import javax.swing.*;
+import java.lang.reflect.InvocationTargetException;
+import java.util.HashMap;
+import java.util.Map;
 
 public class AllForms {
 
     private static AllForms instance;
 
-    private FormDashboard formDashboard;
-    private FormSetting formSetting;
-    private FormModal formModal;
-    private FormToast formToast;
-    private FormDateTime formDateTime;
-    private FormAvatarIcon formAvatarIcon;
-    private FormInput formInput;
-    private FormTable formTable;
-    private FormResponsiveLayout formResponsiveLayout;
+    private final Map<Class<? extends Form>, Form> formsMap;
 
     private static AllForms getInstance() {
         if (instance == null) {
@@ -26,81 +19,25 @@ public class AllForms {
     }
 
     private AllForms() {
+        formsMap = new HashMap<>();
+    }
+
+    public static Form getForm(Class<? extends Form> cls) {
+        if (getInstance().formsMap.containsKey(cls)) {
+            return getInstance().formsMap.get(cls);
+        }
+        try {
+            Form form = cls.getDeclaredConstructor().newInstance();
+            getInstance().formsMap.put(cls, form);
+            formInit(form);
+            return form;
+        } catch (NoSuchMethodException | InvocationTargetException | InstantiationException |
+                 IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public static void formInit(Form form) {
         SwingUtilities.invokeLater(() -> form.formInit());
-    }
-
-    public static Form getFormDashboard() {
-        if (getInstance().formDashboard == null) {
-            getInstance().formDashboard = new FormDashboard();
-            formInit(getInstance().formDashboard);
-        }
-        return getInstance().formDashboard;
-    }
-
-    public static Form getFormSetting() {
-        if (getInstance().formSetting == null) {
-            getInstance().formSetting = new FormSetting();
-            formInit(getInstance().formSetting);
-        }
-        return getInstance().formSetting;
-    }
-
-    public static Form getFormModal() {
-        if (getInstance().formModal == null) {
-            getInstance().formModal = new FormModal();
-            formInit(getInstance().formModal);
-        }
-        return getInstance().formModal;
-    }
-
-    public static Form getFormToast() {
-        if (getInstance().formToast == null) {
-            getInstance().formToast = new FormToast();
-            formInit(getInstance().formToast);
-        }
-        return getInstance().formToast;
-    }
-
-    public static Form getFormDateTime() {
-        if (getInstance().formDateTime == null) {
-            getInstance().formDateTime = new FormDateTime();
-            formInit(getInstance().formDateTime);
-        }
-        return getInstance().formDateTime;
-    }
-
-    public static Form getFormAvatarIcon() {
-        if (getInstance().formAvatarIcon == null) {
-            getInstance().formAvatarIcon = new FormAvatarIcon();
-            formInit(getInstance().formAvatarIcon);
-        }
-        return getInstance().formAvatarIcon;
-    }
-
-    public static Form getFormInput() {
-        if (getInstance().formInput == null) {
-            getInstance().formInput = new FormInput();
-            formInit(getInstance().formInput);
-        }
-        return getInstance().formInput;
-    }
-
-    public static Form getFormTable() {
-        if (getInstance().formTable == null) {
-            getInstance().formTable = new FormTable();
-            formInit(getInstance().formTable);
-        }
-        return getInstance().formTable;
-    }
-
-    public static Form getFormResponsiveLayout() {
-        if (getInstance().formResponsiveLayout == null) {
-            getInstance().formResponsiveLayout = new FormResponsiveLayout();
-            formInit(getInstance().formResponsiveLayout);
-        }
-        return getInstance().formResponsiveLayout;
     }
 }

--- a/demo/src/main/java/raven/modal/demo/system/FormManager.java
+++ b/demo/src/main/java/raven/modal/demo/system/FormManager.java
@@ -2,6 +2,7 @@ package raven.modal.demo.system;
 
 import raven.modal.Drawer;
 import raven.modal.demo.auth.Login;
+import raven.modal.demo.forms.FormDashboard;
 import raven.modal.demo.utils.UndoRedo;
 
 import javax.swing.*;
@@ -63,7 +64,7 @@ public class FormManager {
         frame.getContentPane().removeAll();
         frame.getContentPane().add(getMainForm());
 
-        showForm(AllForms.getFormDashboard());
+        showForm(AllForms.getForm(FormDashboard.class));
         frame.repaint();
         frame.revalidate();
     }

--- a/demo/src/main/java/raven/modal/demo/system/FormManager.java
+++ b/demo/src/main/java/raven/modal/demo/system/FormManager.java
@@ -15,7 +15,12 @@ public class FormManager {
 
     public static void install(JFrame f) {
         frame = f;
+        install();
         logout();
+    }
+
+    private static void install() {
+        FormSearch.getInstance().installKeyMap(getMainForm());
     }
 
     public static void showForm(Form form) {

--- a/demo/src/main/java/raven/modal/demo/system/FormSearch.java
+++ b/demo/src/main/java/raven/modal/demo/system/FormSearch.java
@@ -73,6 +73,7 @@ public class FormSearch {
             searchPanel = new FormSearchPanel(formsMap);
         }
         searchPanel.formCheck();
+        searchPanel.clearSearch();
         return searchPanel;
     }
 }

--- a/demo/src/main/java/raven/modal/demo/system/FormSearch.java
+++ b/demo/src/main/java/raven/modal/demo/system/FormSearch.java
@@ -72,6 +72,7 @@ public class FormSearch {
         if (searchPanel == null) {
             searchPanel = new FormSearchPanel(formsMap);
         }
+        searchPanel.formCheck();
         return searchPanel;
     }
 }

--- a/demo/src/main/java/raven/modal/demo/system/FormSearch.java
+++ b/demo/src/main/java/raven/modal/demo/system/FormSearch.java
@@ -1,0 +1,49 @@
+package raven.modal.demo.system;
+
+import raven.modal.ModalDialog;
+import raven.modal.demo.component.EmptyModalBorder;
+import raven.modal.demo.component.FormSearchPanel;
+import raven.modal.option.Location;
+import raven.modal.option.Option;
+
+import javax.swing.*;
+import java.awt.event.ActionListener;
+import java.awt.event.KeyEvent;
+
+public class FormSearch {
+
+    private static FormSearch instance;
+    private final String ID = "search";
+    private FormSearchPanel searchPanel;
+
+    public static FormSearch getInstance() {
+        if (instance == null) {
+            instance = new FormSearch();
+        }
+        return instance;
+    }
+
+    private FormSearch() {
+    }
+
+    public void installKeyMap(JComponent component) {
+        ActionListener key = e -> showSearch();
+        component.registerKeyboardAction(key, KeyStroke.getKeyStroke(KeyEvent.VK_F, KeyEvent.CTRL_DOWN_MASK), JComponent.WHEN_IN_FOCUSED_WINDOW);
+    }
+
+    public void showSearch() {
+        if (ModalDialog.isIdExist(ID)) {
+            return;
+        }
+        Option option = ModalDialog.createOption();
+        option.getLayoutOption().setMargin(20, 10, 10, 10).setLocation(Location.CENTER, Location.TOP);
+        ModalDialog.showModal(FormManager.getFrame(), new EmptyModalBorder(getSearchPanel()), option, ID);
+    }
+
+    private JPanel getSearchPanel() {
+        if (searchPanel == null) {
+            searchPanel = new FormSearchPanel();
+        }
+        return searchPanel;
+    }
+}

--- a/demo/src/main/java/raven/modal/demo/system/FormSearch.java
+++ b/demo/src/main/java/raven/modal/demo/system/FormSearch.java
@@ -44,7 +44,11 @@ public class FormSearch {
                 FormAvatarIcon.class,
                 FormDateTime.class,
                 FormModal.class,
-                FormInput.class
+                FormToast.class,
+                FormInput.class,
+                FormTable.class,
+                FormResponsiveLayout.class,
+                FormSetting.class
         };
     }
 

--- a/demo/src/main/java/raven/modal/demo/system/FormSearch.java
+++ b/demo/src/main/java/raven/modal/demo/system/FormSearch.java
@@ -3,17 +3,22 @@ package raven.modal.demo.system;
 import raven.modal.ModalDialog;
 import raven.modal.demo.component.EmptyModalBorder;
 import raven.modal.demo.component.FormSearchPanel;
+import raven.modal.demo.forms.*;
+import raven.modal.demo.utils.SystemForm;
 import raven.modal.option.Location;
 import raven.modal.option.Option;
 
 import javax.swing.*;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
+import java.util.HashMap;
+import java.util.Map;
 
 public class FormSearch {
 
     private static FormSearch instance;
-    private final String ID = "search";
+    public static final String ID = "search";
+    private Map<SystemForm, Class<? extends Form>> formsMap;
     private FormSearchPanel searchPanel;
 
     public static FormSearch getInstance() {
@@ -24,6 +29,23 @@ public class FormSearch {
     }
 
     private FormSearch() {
+        formsMap = new HashMap<>();
+        for (Class<? extends Form> cls : getClassForms()) {
+            if (cls.isAnnotationPresent(SystemForm.class)) {
+                SystemForm f = cls.getAnnotation(SystemForm.class);
+                formsMap.put(f, cls);
+            }
+        }
+    }
+
+    private Class<? extends Form>[] getClassForms() {
+        return new Class[]{
+                FormDashboard.class,
+                FormAvatarIcon.class,
+                FormDateTime.class,
+                FormModal.class,
+                FormInput.class
+        };
     }
 
     public void installKeyMap(JComponent component) {
@@ -36,13 +58,15 @@ public class FormSearch {
             return;
         }
         Option option = ModalDialog.createOption();
+        option.setAnimationEnabled(false);
         option.getLayoutOption().setMargin(20, 10, 10, 10).setLocation(Location.CENTER, Location.TOP);
         ModalDialog.showModal(FormManager.getFrame(), new EmptyModalBorder(getSearchPanel()), option, ID);
+        SwingUtilities.invokeLater(() -> searchPanel.searchGrabFocus());
     }
 
     private JPanel getSearchPanel() {
         if (searchPanel == null) {
-            searchPanel = new FormSearchPanel();
+            searchPanel = new FormSearchPanel(formsMap);
         }
         return searchPanel;
     }

--- a/demo/src/main/java/raven/modal/demo/system/MainForm.java
+++ b/demo/src/main/java/raven/modal/demo/system/MainForm.java
@@ -1,8 +1,10 @@
 package raven.modal.demo.system;
 
+import com.formdev.flatlaf.FlatClientProperties;
 import com.formdev.flatlaf.extras.FlatSVGIcon;
 import net.miginfocom.swing.MigLayout;
 import raven.modal.Drawer;
+import raven.modal.demo.component.FormSearchButton;
 import raven.modal.demo.component.RefreshLine;
 
 import javax.swing.*;
@@ -22,7 +24,7 @@ public class MainForm extends JPanel {
     }
 
     private JPanel createHeader() {
-        JPanel panel = new JPanel(new MigLayout("insets 3"));
+        JPanel panel = new JPanel(new MigLayout("insets 3", "[]push[]push", "[fill]"));
         JToolBar toolBar = new JToolBar();
         JButton buttonDrawer = new JButton(new FlatSVGIcon("raven/modal/demo/icons/menu.svg", 0.5f));
         buttonUndo = new JButton(new FlatSVGIcon("raven/modal/demo/icons/undo.svg", 0.5f));
@@ -44,6 +46,15 @@ public class MainForm extends JPanel {
         toolBar.add(buttonRedo);
         toolBar.add(buttonRefresh);
         panel.add(toolBar);
+        panel.add(createSearchBox(), "gapx n 135");
+        return panel;
+    }
+
+    private JPanel createSearchBox() {
+        JPanel panel = new JPanel(new MigLayout("fill", "[fill,center,160:200:]", "[fill]"));
+        FormSearchButton button = new FormSearchButton();
+        button.addActionListener(e -> FormSearch.getInstance().showSearch());
+        panel.add(button);
         return panel;
     }
 

--- a/demo/src/main/java/raven/modal/demo/utils/DemoPreferences.java
+++ b/demo/src/main/java/raven/modal/demo/utils/DemoPreferences.java
@@ -58,9 +58,9 @@ public class DemoPreferences {
     }
 
     public static String[] getRecentSearch() {
-        String stringArr = state.get(KEY_RECENT_SEARCH, null).trim();
-        if (stringArr == null || stringArr.isEmpty()) return null;
-        return stringArr.split(",");
+        String stringArr = state.get(KEY_RECENT_SEARCH, null);
+        if (stringArr == null || stringArr.trim().isEmpty()) return null;
+        return stringArr.trim().split(",");
     }
 
     public static void addRecentSearch(String value) {

--- a/demo/src/main/java/raven/modal/demo/utils/DemoPreferences.java
+++ b/demo/src/main/java/raven/modal/demo/utils/DemoPreferences.java
@@ -5,6 +5,7 @@ import com.formdev.flatlaf.util.LoggingFacade;
 import raven.modal.demo.themes.PanelThemes;
 
 import javax.swing.*;
+import java.util.*;
 import java.util.prefs.Preferences;
 
 public class DemoPreferences {
@@ -12,6 +13,7 @@ public class DemoPreferences {
     public static final String PREFERENCES_ROOT_PATH = "/raven-flatlaf-demo";
     public static final String KEY_LAF = "laf";
     public static final String KEY_LAF_THEME = "lafTheme";
+    public static final String KEY_RECENT_SEARCH = "recentSearch";
 
     public static final String RESOURCE_PREFIX = "res:";
 
@@ -53,5 +55,32 @@ public class DemoPreferences {
                 state.put(KEY_LAF, UIManager.getLookAndFeel().getClass().getName());
             }
         });
+    }
+
+    public static String[] getRecentSearch() {
+        String stringArr = state.get(KEY_RECENT_SEARCH, null).trim();
+        if (stringArr == null || stringArr.isEmpty()) return null;
+        return stringArr.split(",");
+    }
+
+    public static void addRecentSearch(String value) {
+        String[] oldRecent = getRecentSearch();
+        if (oldRecent == null) {
+            state.put(KEY_RECENT_SEARCH, value);
+        } else {
+            List<String> list = new ArrayList<>(Arrays.asList(oldRecent));
+            list.remove(value);
+            list.add(0, value);
+            state.put(KEY_RECENT_SEARCH, String.join(",", list));
+        }
+    }
+
+    public static void removeRecentSearch(String value) {
+        String[] oldRecent = getRecentSearch();
+        if (oldRecent != null) {
+            List<String> list = new ArrayList<>(Arrays.asList(oldRecent));
+            list.remove(value);
+            state.put(KEY_RECENT_SEARCH, String.join(",", list));
+        }
     }
 }

--- a/demo/src/main/java/raven/modal/demo/utils/SystemForm.java
+++ b/demo/src/main/java/raven/modal/demo/utils/SystemForm.java
@@ -1,0 +1,17 @@
+package raven.modal.demo.utils;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SystemForm {
+
+    String name() default "";
+
+    String description() default "";
+
+    String[] tags() default {};
+}


### PR DESCRIPTION
This PR add quick form search.

### How to implement
- Create form with annotation
``` java
import raven.modal.demo.system.Form;
import raven.modal.demo.utils.SystemForm;

@SystemForm(name = "Form Name here", description = "form description here", tags = {"tag 1", "tag 2"})
public class SampleForm extends Form {

    public FormDashboard() {
        // init form
    }
}
```
We can search by `name`  `description` and `tags`
- Go to class `raven.modal.demo.system.FormSearch`
``` java
private Class<? extends Form>[] getClassForms() {
    return new Class[]{
            SampleForm.class,
            // other form class
    };
}
```
### Demo form
![2024-07-26_223153](https://github.com/user-attachments/assets/d4a0bbce-4e5a-49a9-9395-b97ec71b6624)