### PR TITLE
Demo: Make search functionality case-insensitive

### DIFF
--- a/demo/src/main/java/raven/modal/demo/component/FormSearchPanel.java
+++ b/demo/src/main/java/raven/modal/demo/component/FormSearchPanel.java
@@ -101,7 +101,7 @@ public class FormSearchPanel extends JPanel {
             }
 
             private void search() {
-                String st = textSearch.getText().trim();
+                String st = textSearch.getText().trim().toLowerCase(); // Convert search term to lowercase
                 if (!st.equals(text)) {
                     text = st;
                     panelResult.removeAll();
@@ -110,6 +110,7 @@ public class FormSearchPanel extends JPanel {
                     } else {
                         for (Map.Entry<SystemForm, Class<? extends Form>> entry : formsMap.entrySet()) {
                             SystemForm s = entry.getKey();
+                            // Compare both name and description with lowercased search term
                             if (s.name().toLowerCase().contains(st)
                                     || s.description().toLowerCase().contains(st)
                                     || checkTags(s.tags(), st)) {


### PR DESCRIPTION
**Description**:
This modiefies the `search()` method to make the search case-insensitive. Previously, the search was case-sensitive, which caused inconsistent results when users searched with different letter casing than the stored form names or descriptions.

**Changes Made**:
- Converted the search term `st` to lowercase before comparing it to `s.name()` and `s.description()`.

**Additional Info**:
 - This changes are made on issue: #9  