### PR TITLE
Drawer: support for invoke menu event using class

### DIFF
--- a/demo/src/main/java/raven/modal/demo/component/FormSearchPanel.java
+++ b/demo/src/main/java/raven/modal/demo/component/FormSearchPanel.java
@@ -5,6 +5,7 @@ import com.formdev.flatlaf.extras.FlatSVGIcon;
 import com.formdev.flatlaf.icons.FlatClearIcon;
 import com.formdev.flatlaf.icons.FlatMenuArrowIcon;
 import net.miginfocom.swing.MigLayout;
+import raven.modal.Drawer;
 import raven.modal.ModalDialog;
 import raven.modal.component.ModalContainer;
 import raven.modal.demo.layout.ResponsiveLayout;
@@ -382,7 +383,7 @@ public class FormSearchPanel extends JPanel {
 
         protected void showForm() {
             ModalDialog.closeModal(FormSearch.ID);
-            FormManager.showForm(AllForms.getForm(form));
+            Drawer.setSelectedItemClass(form);
             DemoPreferences.addRecentSearch(data.name());
         }
 

--- a/demo/src/main/java/raven/modal/demo/menu/MyDrawerBuilder.java
+++ b/demo/src/main/java/raven/modal/demo/menu/MyDrawerBuilder.java
@@ -3,6 +3,7 @@ package raven.modal.demo.menu;
 import com.formdev.flatlaf.FlatClientProperties;
 import raven.modal.demo.forms.*;
 import raven.modal.demo.system.AllForms;
+import raven.modal.demo.system.Form;
 import raven.modal.demo.system.FormManager;
 import raven.modal.drawer.DrawerPanel;
 import raven.modal.drawer.data.Item;
@@ -51,17 +52,17 @@ public class MyDrawerBuilder extends SimpleDrawerBuilder {
         if (menuOption == null) {
             MenuItem items[] = new MenuItem[]{
                     new Item.Label("MAIN"),
-                    new Item("Dashboard", "dashboard.svg"),
+                    new Item("Dashboard", "dashboard.svg", FormDashboard.class),
                     new Item.Label("SWING UI"),
                     new Item("Forms", "forms.svg")
-                            .subMenu("Input")
-                            .subMenu("Table")
-                            .subMenu("Responsive Layout"),
+                            .subMenu("Input", FormInput.class)
+                            .subMenu("Table", FormTable.class)
+                            .subMenu("Responsive Layout", FormResponsiveLayout.class),
                     new Item("Components", "components.svg")
-                            .subMenu("Modal")
-                            .subMenu("Toast")
-                            .subMenu("Date Time")
-                            .subMenu("Avatar Icon"),
+                            .subMenu("Modal", FormModal.class)
+                            .subMenu("Toast", FormToast.class)
+                            .subMenu("Date Time", FormDateTime.class)
+                            .subMenu("Avatar Icon", FormAvatarIcon.class),
                     new Item("Email", "email.svg")
                             .subMenu("Inbox")
                             .subMenu(
@@ -89,7 +90,7 @@ public class MyDrawerBuilder extends SimpleDrawerBuilder {
                             .subMenu("Plugin 1")
                             .subMenu("Plugin 2")
                             .subMenu("Plugin 3"),
-                    new Item("Setting", "setting.svg"),
+                    new Item("Setting", "setting.svg", FormSetting.class),
                     new Item("Logout", "logout.svg")
             };
 
@@ -118,39 +119,19 @@ public class MyDrawerBuilder extends SimpleDrawerBuilder {
                 @Override
                 public void selected(MenuAction action, int[] index) {
                     System.out.println("Drawer menu selected " + Arrays.toString(index));
-                    if (index.length == 1) {
-                        int i = index[0];
-                        if (i == 0) {
-                            FormManager.showForm(AllForms.getForm(FormDashboard.class));
-                        } else if (i == 7) {
-                            FormManager.showForm(AllForms.getForm(FormSetting.class));
-                        } else if (i == 8) {
-                            FormManager.logout();
-                            action.consume();
-                        }
-                    } else if (index.length == 2) {
-                        int i = index[0];
-                        int j = index[1];
-                        if (i == 1) {
-                            if (j == 0) {
-                                FormManager.showForm(AllForms.getForm(FormInput.class));
-                            } else if (j == 1) {
-                                FormManager.showForm(AllForms.getForm(FormTable.class));
-                            } else if (j == 2) {
-                                FormManager.showForm(AllForms.getForm(FormResponsiveLayout.class));
-                            }
-                        } else if (i == 2) {
-                            if (j == 0) {
-                                FormManager.showForm(AllForms.getForm(FormModal.class));
-                            } else if (j == 1) {
-                                FormManager.showForm(AllForms.getForm(FormToast.class));
-                            } else if (j == 2) {
-                                FormManager.showForm(AllForms.getForm(FormDateTime.class));
-                            } else if (j == 3) {
-                                FormManager.showForm(AllForms.getForm(FormAvatarIcon.class));
-                            }
-                        }
+                    Class<?> itemClass = action.getItem().getItemClass();
+                    int i = index[0];
+                    if (i == 8) {
+                        action.consume();
+                        FormManager.logout();
+                        return;
                     }
+                    if (itemClass == null || !Form.class.isAssignableFrom(itemClass)) {
+                        action.consume();
+                        return;
+                    }
+                    Class<? extends Form> formClass = (Class<? extends Form>) itemClass;
+                    FormManager.showForm(AllForms.getForm(formClass));
                 }
             });
 

--- a/demo/src/main/java/raven/modal/demo/system/FormManager.java
+++ b/demo/src/main/java/raven/modal/demo/system/FormManager.java
@@ -4,7 +4,6 @@ import raven.modal.Drawer;
 import raven.modal.demo.auth.Login;
 import raven.modal.demo.forms.FormDashboard;
 import raven.modal.demo.utils.UndoRedo;
-import raven.modal.drawer.simple.SimpleDrawerBuilder;
 
 import javax.swing.*;
 
@@ -65,8 +64,7 @@ public class FormManager {
         frame.getContentPane().removeAll();
         frame.getContentPane().add(getMainForm());
 
-        showForm(AllForms.getForm(FormDashboard.class));
-        setSelectedMenuIndex(new int[]{0});
+        Drawer.setSelectedItemClass(FormDashboard.class);
         frame.repaint();
         frame.revalidate();
     }
@@ -84,11 +82,6 @@ public class FormManager {
 
     public static JFrame getFrame() {
         return frame;
-    }
-
-    public static void setSelectedMenuIndex(int[] index) {
-        SimpleDrawerBuilder simpleDrawerBuilder = (SimpleDrawerBuilder) Drawer.getDrawerBuilder();
-        simpleDrawerBuilder.getDrawerMenu().setMenuSelectedIndex(index);
     }
 
     private static MainForm getMainForm() {

--- a/modal-dialog/src/main/java/raven/modal/Drawer.java
+++ b/modal-dialog/src/main/java/raven/modal/Drawer.java
@@ -4,6 +4,7 @@ import raven.modal.component.ModalContainer;
 import raven.modal.drawer.DrawerBuilder;
 import raven.modal.drawer.DrawerLayoutResponsive;
 import raven.modal.drawer.DrawerPanel;
+import raven.modal.drawer.simple.SimpleDrawerBuilder;
 import raven.modal.option.Option;
 
 import javax.swing.*;
@@ -85,5 +86,10 @@ public class Drawer {
 
     public static DrawerBuilder getDrawerBuilder() {
         return instance.drawerPanel.getDrawerBuilder();
+    }
+
+    public static void setSelectedItemClass(Class<?> itemClass) {
+        SimpleDrawerBuilder drawerBuilder = (SimpleDrawerBuilder) instance.drawerPanel.getDrawerBuilder();
+        drawerBuilder.getDrawerMenu().setMenuSelectedClass(itemClass);
     }
 }

--- a/modal-dialog/src/main/java/raven/modal/drawer/data/Item.java
+++ b/modal-dialog/src/main/java/raven/modal/drawer/data/Item.java
@@ -8,6 +8,10 @@ import java.util.List;
  */
 public class Item implements MenuItem {
 
+    public int[] getIndex() {
+        return index;
+    }
+
     public String getName() {
         return name;
     }
@@ -20,17 +24,34 @@ public class Item implements MenuItem {
         return subMenu;
     }
 
+    public Class<?> getItemClass() {
+        return itemClass;
+    }
+
     private final String name;
     private String icon;
     private List<Item> subMenu;
+    private Class<?> itemClass;
+    private int[] index;
 
     public Item(String name) {
         this.name = name;
     }
 
+    public Item(String name, Class<?> itemClass) {
+        this.name = name;
+        this.itemClass = itemClass;
+    }
+
     public Item(String name, String icon) {
         this.name = name;
         this.icon = icon;
+    }
+
+    public Item(String name, String icon, Class<?> itemClass) {
+        this.name = name;
+        this.icon = icon;
+        this.itemClass = itemClass;
     }
 
     public Item subMenu(Item item) {
@@ -43,6 +64,11 @@ public class Item implements MenuItem {
         return this;
     }
 
+    public Item subMenu(String name, Class<?> itemClass) {
+        addSubMenu(new Item(name, itemClass));
+        return this;
+    }
+
     private void addSubMenu(Item item) {
         if (subMenu == null) {
             subMenu = new ArrayList<>();
@@ -52,6 +78,12 @@ public class Item implements MenuItem {
 
     public boolean isSubmenuAble() {
         return subMenu != null;
+    }
+
+    public void initIndexOnNull(int[] index) {
+        if (this.index == null) {
+            this.index = index;
+        }
     }
 
     @Override

--- a/modal-dialog/src/main/java/raven/modal/drawer/menu/MenuAction.java
+++ b/modal-dialog/src/main/java/raven/modal/drawer/menu/MenuAction.java
@@ -1,11 +1,18 @@
 package raven.modal.drawer.menu;
 
+import raven.modal.drawer.data.Item;
+
 /**
  * @author Raven
  */
 public class MenuAction {
 
     private boolean consume;
+    private Item item;
+
+    public MenuAction(Item item) {
+        this.item = item;
+    }
 
     protected boolean getConsume() {
         return consume;
@@ -13,5 +20,9 @@ public class MenuAction {
 
     public void consume() {
         consume = true;
+    }
+
+    public Item getItem() {
+        return item;
     }
 }


### PR DESCRIPTION
This PR update drawer menu

### Menu options changed

``` java
// create menu item
MenuItem items[] = new MenuItem[]{
        new Item.Label("MAIN"),
        new Item("Dashboard", "dashboard.svg", FormDashboard.class),
        new Item("Setting", "setting.svg", FormSetting.class),
        new Item.Label("SWING UI")
};

// set menu item to options
menuOption.setMenus(items);
```

Add event menu

``` java
menuOption.addMenuEvent(new MenuEvent() {
    @Override
    public void selected(MenuAction action, int[] index) {
        Class<?> itemClass = action.getItem().getItemClass();
        if (itemClass == null || !Form.class.isAssignableFrom(itemClass)) {
            action.consume();
            return;
        }
        Class<? extends Form> formClass = (Class<? extends Form>) itemClass;
        try {
            Form form = formClass.getDeclaredConstructor().newInstance();
            FormManager.showForm(form);
        } catch (Exception e) {
        }
    }
});
```

### New method

Set selected menu item by using class

``` java
Drawer.setSelectedItemClass(FormDashboard.class);
```