### PR TITLE
Modal Dialog: update add border option and fixed push modal

### DIFF
--- a/demo/src/main/java/raven/modal/demo/forms/FormModal.java
+++ b/demo/src/main/java/raven/modal/demo/forms/FormModal.java
@@ -45,7 +45,7 @@ public class FormModal extends Form {
     }
 
     private Component createOptions() {
-        JPanel panel = new JPanel(new MigLayout("wrap 2,fillx", "[grow 0,fill][fill]"));
+        JPanel panel = new JPanel(new MigLayout("wrap 2,fillx", "[grow 0,fill][fill]", "[fill]"));
         panel.add(createHorizontalOption());
         panel.add(createVerticalOption());
         panel.add(createModalOptions());
@@ -105,15 +105,17 @@ public class FormModal extends Form {
     }
 
     private Component createModalOptions() {
-        JPanel panel = new JPanel(new MigLayout());
+        JPanel panel = new JPanel(new MigLayout("wrap 2"));
         panel.setBorder(new TitledBorder("Options"));
         chAnimation = new JCheckBox("Animation enable");
         chCloseOnPressedEscape = new JCheckBox("Close on pressed escape");
+        chBorder = new JCheckBox("Border");
         chAnimation.setSelected(true);
         chCloseOnPressedEscape.setSelected(true);
 
         panel.add(chAnimation);
         panel.add(chCloseOnPressedEscape);
+        panel.add(chBorder);
 
         return panel;
     }
@@ -202,11 +204,20 @@ public class FormModal extends Form {
         option.getLayoutOption().setSize(-1, 1f)
                 .setOnTop(true)
                 .setAnimateDistance(0.7f, 0);
+
+        final String id = "input";
         ModalDialog.showModal(this, new SimpleModalBorder(
                 new SimpleInputForms(), "Sample Input Forms", SimpleModalBorder.YES_NO_CANCEL_OPTION,
                 (controller, action) -> {
-                    controller.close();
-                }), option);
+                    if (action == SimpleModalBorder.YES_OPTION) {
+
+                        // consume no close modal
+                        controller.consume();
+
+                        // push modal
+                        ModalDialog.pushModal(new SimpleModalBorder(new SimpleInputForms(), "New Input Forms", SimpleModalBorder.YES_NO_OPTION, null), id);
+                    }
+                }), option, id);
     }
 
     private Option getSelectedOption() {
@@ -216,7 +227,8 @@ public class FormModal extends Form {
         Option.BackgroundClickType backgroundClickType = jrClose.isSelected() ? Option.BackgroundClickType.CLOSE_MODAL : jrBlock.isSelected() ? Option.BackgroundClickType.BLOCK : Option.BackgroundClickType.NONE;
         option.setAnimationEnabled(chAnimation.isSelected())
                 .setCloseOnPressedEscape(chCloseOnPressedEscape.isSelected())
-                .setBackgroundClickType(backgroundClickType);
+                .setBackgroundClickType(backgroundClickType)
+                .setBorderWidth(chBorder.isSelected() ? 1f : 0);
         option.getLayoutOption().setLocation(h, v);
         return option;
     }
@@ -236,6 +248,7 @@ public class FormModal extends Form {
     // option
     private JCheckBox chAnimation;
     private JCheckBox chCloseOnPressedEscape;
+    private JCheckBox chBorder;
 
     // background click option
     private JRadioButton jrClose;

--- a/demo/src/main/java/raven/modal/demo/menu/MyDrawerBuilder.java
+++ b/demo/src/main/java/raven/modal/demo/menu/MyDrawerBuilder.java
@@ -44,7 +44,7 @@ public class MyDrawerBuilder extends SimpleDrawerBuilder {
     public SimpleFooterData getSimpleFooterData() {
         return new SimpleFooterData()
                 .setTitle("Swing Modal Dialog")
-                .setDescription("Version 1.2.0");
+                .setDescription("Version 1.2.1");
     }
 
     @Override

--- a/demo/src/test/java/test/Test.java
+++ b/demo/src/test/java/test/Test.java
@@ -6,6 +6,7 @@ import net.miginfocom.swing.MigLayout;
 import raven.modal.ModalDialog;
 import raven.modal.component.SimpleModalBorder;
 import raven.modal.demo.simple.SimpleInputForms;
+import raven.modal.option.Option;
 
 import javax.swing.*;
 import java.awt.*;
@@ -22,7 +23,7 @@ public class Test extends JFrame {
             ModalDialog.showModal(this, new SimpleModalBorder(new SimpleInputForms(), "Input", SimpleModalBorder.YES_NO_OPTION, (controller, action) -> {
                 //  controller.consume();
                 System.out.println(action);
-            }));
+            }), new Option().setBorderWidth(1), "input");
         });
         add(button);
     }

--- a/demo/src/test/java/test/Test.java
+++ b/demo/src/test/java/test/Test.java
@@ -19,6 +19,10 @@ public class Test extends JFrame {
         setLocationRelativeTo(null);
         setLayout(new MigLayout("al center center"));
         JButton button = new JButton("show");
+        ModalDialog.getDefaultOption()
+                .setBorderWidth(1f)
+                .setBorderColor(new Color(22, 103, 92));
+
         button.addActionListener(e -> {
             ModalDialog.showModal(this, new SimpleModalBorder(new SimpleInputForms(), "Input", SimpleModalBorder.YES_NO_OPTION, (controller, action) -> {
                 System.out.println(action);
@@ -27,7 +31,7 @@ public class Test extends JFrame {
                     ModalDialog.pushModal(new SimpleModalBorder(new SimpleInputForms(), "New Input", SimpleModalBorder.YES_NO_OPTION, (controller1, action1) -> {
                     }), "input");
                 }
-            }), new Option().setBorderWidth(0.5f), "input");
+            }), "input");
         });
         add(button);
     }

--- a/demo/src/test/java/test/Test.java
+++ b/demo/src/test/java/test/Test.java
@@ -21,9 +21,13 @@ public class Test extends JFrame {
         JButton button = new JButton("show");
         button.addActionListener(e -> {
             ModalDialog.showModal(this, new SimpleModalBorder(new SimpleInputForms(), "Input", SimpleModalBorder.YES_NO_OPTION, (controller, action) -> {
-                //  controller.consume();
                 System.out.println(action);
-            }), new Option().setBorderWidth(1), "input");
+                if (action == SimpleModalBorder.YES_OPTION) {
+                    controller.consume();
+                    ModalDialog.pushModal(new SimpleModalBorder(new SimpleInputForms(), "New Input", SimpleModalBorder.YES_NO_OPTION, (controller1, action1) -> {
+                    }), "input");
+                }
+            }), new Option().setBorderWidth(0.5f), "input");
         });
         add(button);
     }

--- a/modal-dialog/pom.xml
+++ b/modal-dialog/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.dj-raven</groupId>
     <artifactId>modal-dialog</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>

--- a/modal-dialog/src/main/java/raven/modal/component/ModalController.java
+++ b/modal-dialog/src/main/java/raven/modal/component/ModalController.java
@@ -11,6 +11,7 @@ import raven.modal.slider.SimpleTransition;
 import raven.modal.utils.ImageSnapshots;
 
 import javax.swing.*;
+import javax.swing.border.Border;
 import java.awt.*;
 import java.awt.event.MouseAdapter;
 import java.util.Stack;
@@ -49,6 +50,9 @@ public class ModalController extends JPanel {
 
         setLayout(new MigLayout("fill,insets 0", "[fill,5::]", "[fill,5::]"));
         setOpaque(false);
+        if (option.getBorderWidth() > 0) {
+            setBorder(new OutlineBorder(option.getRound()));
+        }
         panelSlider = new PanelSlider((int) (option.getRound() / 2f));
         add(panelSlider);
     }
@@ -196,11 +200,16 @@ public class ModalController extends JPanel {
     @Override
     protected void paintComponent(Graphics g) {
         Graphics2D g2d = (Graphics2D) g.create();
+        Insets insets = getInsets();
+        int x = insets.left;
+        int y = insets.top;
+        int width = getWidth() - (insets.left + insets.right);
+        int height = getHeight() - (insets.top + insets.bottom);
         FlatUIUtils.setRenderingHints(g2d);
         g2d.setColor(getBackground());
         float arc = UIScale.scale(option.getRound());
         g2d.setComposite(AlphaComposite.SrcOver.derive(animated));
-        FlatUIUtils.paintComponentBackground(g2d, 0, 0, getWidth(), getHeight(), 0, arc);
+        FlatUIUtils.paintComponentBackground(g2d, x, y, width, height, 0, arc);
         g2d.dispose();
         super.paintComponent(g);
     }
@@ -214,6 +223,10 @@ public class ModalController extends JPanel {
                 Insets insets = getInsets();
                 // draw snapshots image
                 g2.drawImage(snapshotsImage, insets.left, insets.top, null);
+                Border border = getBorder();
+                if (border != null) {
+                    getBorder().paintBorder(this, g2, 0, 0, getWidth(), getHeight());
+                }
                 g2.dispose();
             } else {
                 super.paint(g);

--- a/modal-dialog/src/main/java/raven/modal/component/ModalController.java
+++ b/modal-dialog/src/main/java/raven/modal/component/ModalController.java
@@ -72,6 +72,7 @@ public class ModalController extends JPanel {
     }
 
     public void pushModal(Modal modal) {
+        installModalComponent(modal);
         if (modal instanceof SimpleModalBorder) {
             SimpleModalBorder simpleModalBorder = (SimpleModalBorder) modal;
             simpleModalBorder.createBackButton(getOnBackAction());
@@ -94,11 +95,7 @@ public class ModalController extends JPanel {
 
     public void showModal() {
         setFocusCycleRoot(true);
-        // install the modal component for the first show
-        if (!modal.isInstalled()) {
-            modal.installComponent();
-            modal.setInstalled(true);
-        }
+        installModalComponent(modal);
         modal.grabFocus();
         startAnimator(true);
     }
@@ -188,6 +185,14 @@ public class ModalController extends JPanel {
                 animated = 0;
                 remove();
             }
+        }
+    }
+
+    private void installModalComponent(Modal modal) {
+        // install the modal component for the first show
+        if (!modal.isInstalled()) {
+            modal.installComponent();
+            modal.setInstalled(true);
         }
     }
 

--- a/modal-dialog/src/main/java/raven/modal/component/ModalController.java
+++ b/modal-dialog/src/main/java/raven/modal/component/ModalController.java
@@ -51,7 +51,7 @@ public class ModalController extends JPanel {
         setLayout(new MigLayout("fill,insets 0", "[fill,5::]", "[fill,5::]"));
         setOpaque(false);
         if (option.getBorderWidth() > 0) {
-            setBorder(new OutlineBorder(option.getRound()));
+            setBorder(new OutlineBorder(option.getBorderWidth(), option.getRound()));
         }
         panelSlider = new PanelSlider((int) (option.getRound() / 2f));
         add(panelSlider);
@@ -212,7 +212,7 @@ public class ModalController extends JPanel {
         int height = getHeight() - (insets.top + insets.bottom);
         FlatUIUtils.setRenderingHints(g2d);
         g2d.setColor(getBackground());
-        float arc = UIScale.scale(option.getRound());
+        float arc = UIScale.scale(option.getRound()) - UIScale.scale(option.getBorderWidth() * 2f);
         g2d.setComposite(AlphaComposite.SrcOver.derive(animated));
         FlatUIUtils.paintComponentBackground(g2d, x, y, width, height, 0, arc);
         g2d.dispose();

--- a/modal-dialog/src/main/java/raven/modal/component/ModalController.java
+++ b/modal-dialog/src/main/java/raven/modal/component/ModalController.java
@@ -51,7 +51,7 @@ public class ModalController extends JPanel {
         setLayout(new MigLayout("fill,insets 0", "[fill,5::]", "[fill,5::]"));
         setOpaque(false);
         if (option.getBorderWidth() > 0) {
-            setBorder(new OutlineBorder(option.getBorderWidth(), option.getRound()));
+            setBorder(new OutlineBorder(option.getBorderWidth(), option.getRound(), option.getBorderColor()));
         }
         panelSlider = new PanelSlider((int) (option.getRound() / 2f));
         add(panelSlider);
@@ -144,7 +144,7 @@ public class ModalController extends JPanel {
                     @Override
                     public void begin() {
                         modalContainer.showSnapshot();
-                        snapshotsImage = ImageSnapshots.createSnapshotsImage(panelSlider, option.getRound());
+                        snapshotsImage = ImageSnapshots.createSnapshotsImage(panelSlider, getOptionRound());
                         panelSlider.setVisible(false);
                         display = true;
                     }
@@ -202,6 +202,10 @@ public class ModalController extends JPanel {
         modalContainerLayer.revalidate();
     }
 
+    private float getOptionRound() {
+        return option.getRound() - option.getBorderWidth() * 2f;
+    }
+
     @Override
     protected void paintComponent(Graphics g) {
         Graphics2D g2d = (Graphics2D) g.create();
@@ -212,7 +216,7 @@ public class ModalController extends JPanel {
         int height = getHeight() - (insets.top + insets.bottom);
         FlatUIUtils.setRenderingHints(g2d);
         g2d.setColor(getBackground());
-        float arc = UIScale.scale(option.getRound()) - UIScale.scale(option.getBorderWidth() * 2f);
+        float arc = UIScale.scale(getOptionRound());
         g2d.setComposite(AlphaComposite.SrcOver.derive(animated));
         FlatUIUtils.paintComponentBackground(g2d, x, y, width, height, 0, arc);
         g2d.dispose();

--- a/modal-dialog/src/main/java/raven/modal/component/OutlineBorder.java
+++ b/modal-dialog/src/main/java/raven/modal/component/OutlineBorder.java
@@ -16,10 +16,12 @@ public class OutlineBorder extends AbstractBorder {
 
     private final float borderWidth;
     private final float round;
+    private final Color borderColor;
 
-    public OutlineBorder(float borderWidth, float round) {
+    public OutlineBorder(float borderWidth, float round, Color borderColor) {
         this.borderWidth = borderWidth;
         this.round = round;
+        this.borderColor = borderColor;
     }
 
     @Override
@@ -46,6 +48,9 @@ public class OutlineBorder extends AbstractBorder {
     }
 
     protected Color getBorderColor() {
+        if (borderColor != null) {
+            return borderColor;
+        }
         Color color = UIManager.getColor("Component.borderColor");
         return color;
     }

--- a/modal-dialog/src/main/java/raven/modal/component/OutlineBorder.java
+++ b/modal-dialog/src/main/java/raven/modal/component/OutlineBorder.java
@@ -14,9 +14,11 @@ import static com.formdev.flatlaf.util.UIScale.scale;
  */
 public class OutlineBorder extends AbstractBorder {
 
+    private final float borderWidth;
     private final float round;
 
-    public OutlineBorder(float round) {
+    public OutlineBorder(float borderWidth, float round) {
+        this.borderWidth = borderWidth;
         this.round = round;
     }
 
@@ -49,6 +51,6 @@ public class OutlineBorder extends AbstractBorder {
     }
 
     protected float getBorderWidth() {
-        return FlatUIUtils.getUIFloat("Component.borderWidth", 1);
+        return scale(borderWidth);
     }
 }

--- a/modal-dialog/src/main/java/raven/modal/component/OutlineBorder.java
+++ b/modal-dialog/src/main/java/raven/modal/component/OutlineBorder.java
@@ -1,0 +1,54 @@
+package raven.modal.component;
+
+import com.formdev.flatlaf.ui.FlatUIUtils;
+import com.formdev.flatlaf.util.UIScale;
+
+import javax.swing.*;
+import javax.swing.border.AbstractBorder;
+import java.awt.*;
+
+import static com.formdev.flatlaf.util.UIScale.scale;
+
+/**
+ * @author Raven
+ */
+public class OutlineBorder extends AbstractBorder {
+
+    private final float round;
+
+    public OutlineBorder(float round) {
+        this.round = round;
+    }
+
+    @Override
+    public void paintBorder(Component c, Graphics g, int x, int y, int width, int height) {
+        Graphics2D g2 = (Graphics2D) g.create();
+        FlatUIUtils.setRenderingHints(g2);
+        Color color = getBorderColor();
+        g2.setColor(color);
+        float lineWidth = UIScale.scale(getBorderWidth());
+        float arc = UIScale.scale(round);
+        FlatUIUtils.paintOutline(g2, x, y, width, height, lineWidth, arc);
+        g2.dispose();
+    }
+
+    @Override
+    public Insets getBorderInsets(Component c, Insets insets) {
+        int lineWidth = Math.round(UIScale.scale(getBorderWidth()));
+        insets = super.getBorderInsets(c, insets);
+        insets.top = scale(insets.top) + lineWidth;
+        insets.left = scale(insets.left) + lineWidth;
+        insets.bottom = scale(insets.bottom) + lineWidth;
+        insets.right = scale(insets.right) + lineWidth;
+        return insets;
+    }
+
+    protected Color getBorderColor() {
+        Color color = UIManager.getColor("Component.borderColor");
+        return color;
+    }
+
+    protected float getBorderWidth() {
+        return FlatUIUtils.getUIFloat("Component.borderWidth", 1);
+    }
+}

--- a/modal-dialog/src/main/java/raven/modal/component/SimpleModalBorder.java
+++ b/modal-dialog/src/main/java/raven/modal/component/SimpleModalBorder.java
@@ -183,7 +183,7 @@ public class SimpleModalBorder extends Modal implements ModalBorderAction {
 
     public void createBackButton(Consumer onBack) {
         if (header != null) {
-            JButton buttonClose = new JButton(new FlatSVGIcon("raven/modal/icon/back.svg", 0.45f));
+            JButton buttonClose = new JButton(new FlatSVGIcon("raven/modal/icon/back.svg", 0.4f));
             buttonClose.addActionListener(e -> onBack.accept(null));
             buttonClose.putClientProperty(FlatClientProperties.STYLE, "" +
                     "arc:999;" +

--- a/modal-dialog/src/main/java/raven/modal/option/Option.java
+++ b/modal-dialog/src/main/java/raven/modal/option/Option.java
@@ -69,7 +69,7 @@ public class Option {
     private float opacity = 0.5f;
     private int duration = 350;
 
-    private Option(LayoutOption layoutOption, BackgroundClickType backgroundClickType, boolean animationEnabled, boolean closeOnPressedEscape, Color backgroundLight, Color backgroundDark, float round, float opacity, int duration) {
+    private Option(LayoutOption layoutOption, BackgroundClickType backgroundClickType, boolean animationEnabled, boolean closeOnPressedEscape, Color backgroundLight, Color backgroundDark, float round, float borderWidth, Color borderColor, float opacity, int duration) {
         this.layoutOption = layoutOption;
         this.backgroundClickType = backgroundClickType;
         this.animationEnabled = animationEnabled;
@@ -77,6 +77,8 @@ public class Option {
         this.backgroundLight = backgroundLight;
         this.backgroundDark = backgroundDark;
         this.round = round;
+        this.borderWidth = borderWidth;
+        this.borderColor = borderColor;
         this.opacity = opacity;
         this.duration = duration;
     }
@@ -146,6 +148,6 @@ public class Option {
     }
 
     public Option copy() {
-        return new Option(layoutOption.copy(), backgroundClickType, animationEnabled, closeOnPressedEscape, backgroundLight == null ? null : new Color(backgroundLight.getRGB()), backgroundDark == null ? null : new Color(backgroundDark.getRGB()), round, opacity, duration);
+        return new Option(layoutOption.copy(), backgroundClickType, animationEnabled, closeOnPressedEscape, backgroundLight == null ? null : new Color(backgroundLight.getRGB()), backgroundDark == null ? null : new Color(backgroundDark.getRGB()), round, borderWidth, borderColor, opacity, duration);
     }
 }

--- a/modal-dialog/src/main/java/raven/modal/option/Option.java
+++ b/modal-dialog/src/main/java/raven/modal/option/Option.java
@@ -41,6 +41,10 @@ public class Option {
         return round;
     }
 
+    public float getBorderWidth() {
+        return borderWidth;
+    }
+
     public float getOpacity() {
         return opacity;
     }
@@ -56,6 +60,7 @@ public class Option {
     private Color backgroundLight;
     private Color backgroundDark;
     private float round = 20;
+    private float borderWidth = 0;
     private float opacity = 0.5f;
     private int duration = 350;
 
@@ -108,6 +113,11 @@ public class Option {
 
     public Option setRound(float round) {
         this.round = round;
+        return this;
+    }
+
+    public Option setBorderWidth(float borderWidth) {
+        this.borderWidth = borderWidth;
         return this;
     }
 

--- a/modal-dialog/src/main/java/raven/modal/option/Option.java
+++ b/modal-dialog/src/main/java/raven/modal/option/Option.java
@@ -45,6 +45,10 @@ public class Option {
         return borderWidth;
     }
 
+    public Color getBorderColor() {
+        return borderColor;
+    }
+
     public float getOpacity() {
         return opacity;
     }
@@ -61,6 +65,7 @@ public class Option {
     private Color backgroundDark;
     private float round = 20;
     private float borderWidth = 0;
+    private Color borderColor;
     private float opacity = 0.5f;
     private int duration = 350;
 
@@ -118,6 +123,11 @@ public class Option {
 
     public Option setBorderWidth(float borderWidth) {
         this.borderWidth = borderWidth;
+        return this;
+    }
+
+    public Option setBorderColor(Color borderColor) {
+        this.borderColor = borderColor;
         return this;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     </repositories>
 
     <properties>
-        <revision>1.2.0</revision>
+        <revision>1.2.1-SNAPSHOT</revision>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
This PR update add modal border option and fixed push `modal`
By default borderWidth is `0`

### Modal border option

Apply default to all border option
``` java
ModalDialog.getDefaultOption()
        .setBorderWidth(1f);
```
Individual apply
``` java
Option option = ModalDialog.createOption();
option.setBorderWidth(1f);
```
![2024-09-24_223549](https://github.com/user-attachments/assets/552d2836-2f8d-474b-a826-b6f77ec4ef84)

The default border color use flatlaf properties `Component.borderColor`
But we can change it

``` java
ModalDialog.getDefaultOption()
        .setBorderWidth(1f)
        .setBorderColor(new Color(22, 103, 92));
```

or

``` java
Option option = ModalDialog.createOption();
option.setBorderWidth(1f)
        .setBorderColor(new Color(22, 103, 92));
```

![2024-09-24_223639](https://github.com/user-attachments/assets/9a22e515-fed3-43ec-b42a-68e52da55059)