### PR TITLE
Modal Dialog: add new blur background option

### DIFF
--- a/demo/src/main/java/raven/modal/demo/component/FormSearchPanel.java
+++ b/demo/src/main/java/raven/modal/demo/component/FormSearchPanel.java
@@ -104,6 +104,7 @@ public class FormSearchPanel extends JPanel {
                 String st = textSearch.getText().trim().toLowerCase(); // Convert search term to lowercase
                 if (!st.equals(text)) {
                     text = st;
+                    int oldSize = listItems.size();
                     panelResult.removeAll();
                     listItems.clear();
                     if (st.isEmpty()) {
@@ -125,8 +126,9 @@ public class FormSearchPanel extends JPanel {
                         } else {
                             panelResult.add(createNoResult(st));
                         }
-                        panelResult.repaint();
-                        updateLayout();
+                        if (oldSize != listItems.size()) {
+                            updateLayout();
+                        }
                     }
                 }
             }
@@ -207,6 +209,7 @@ public class FormSearchPanel extends JPanel {
     private void showRecentResult() {
         String[] recentSearch = DemoPreferences.getRecentSearch(false);
         String[] favoriteSearch = DemoPreferences.getRecentSearch(true);
+        int oldSize = listItems.size();
         panelResult.removeAll();
         listItems.clear();
         if (recentSearch != null && recentSearch.length > 0) {
@@ -237,7 +240,9 @@ public class FormSearchPanel extends JPanel {
         } else {
             setSelected(0);
         }
-        updateLayout();
+        if (oldSize != listItems.size()) {
+            updateLayout();
+        }
     }
 
     private JLabel createLabel(String title) {

--- a/demo/src/main/java/raven/modal/demo/forms/FormModal.java
+++ b/demo/src/main/java/raven/modal/demo/forms/FormModal.java
@@ -114,6 +114,7 @@ public class FormModal extends Form {
         chBorder = new JCheckBox("Outline border");
         chShadow = new JCheckBox("Shadow border");
         chOpacity = new JCheckBox("Background opacity");
+        chBackgroundBlur = new JCheckBox("Background blur");
 
         chAnimation.setSelected(true);
         chCloseOnPressedEscape.setSelected(true);
@@ -124,6 +125,7 @@ public class FormModal extends Form {
         panel.add(chBorder);
         panel.add(chShadow);
         panel.add(chOpacity);
+        panel.add(chBackgroundBlur);
 
         return panel;
     }
@@ -209,9 +211,6 @@ public class FormModal extends Form {
     }
 
     private void showModalSlide(Option option) {
-        option.getLayoutOption()
-                .setOnTop(true);
-
         final String id = "input";
         ModalDialog.showModal(this, new SimpleModalBorder(
                 new SimpleInputForms(), "Sample Input Forms", SimpleModalBorder.YES_NO_CANCEL_OPTION,
@@ -235,7 +234,8 @@ public class FormModal extends Form {
         option.setAnimationEnabled(chAnimation.isSelected())
                 .setCloseOnPressedEscape(chCloseOnPressedEscape.isSelected())
                 .setBackgroundClickType(backgroundClickType)
-                .setOpacity(chOpacity.isSelected() ? 0.5f : 0);
+                .setOpacity(chOpacity.isSelected() ? 0.5f : 0)
+                .setBackgroundBlur(chBackgroundBlur.isSelected() ? Option.BackgroundBlur.SMALL : Option.BackgroundBlur.NONE);
         option.getBorderOption()
                 .setBorderWidth(chBorder.isSelected() ? 1f : 0)
                 .setShadow(chShadow.isSelected() ? BorderOption.Shadow.MEDIUM : BorderOption.Shadow.NONE);
@@ -261,6 +261,7 @@ public class FormModal extends Form {
     private JCheckBox chBorder;
     private JCheckBox chShadow;
     private JCheckBox chOpacity;
+    private JCheckBox chBackgroundBlur;
 
     // background click option
     private JRadioButton jrClose;

--- a/demo/src/main/java/raven/modal/demo/menu/MyDrawerBuilder.java
+++ b/demo/src/main/java/raven/modal/demo/menu/MyDrawerBuilder.java
@@ -175,7 +175,8 @@ public class MyDrawerBuilder extends SimpleDrawerBuilder {
     @Override
     public Option getOption() {
         Option option = super.getOption();
-        option.setOpacity(0.3f);
+        option.setOpacity(0.3f)
+                .setBackgroundBlur(Option.BackgroundBlur.SMALL);
         option.getBorderOption()
                 .setShadowSize(new Insets(0, 0, 0, SHADOW_SIZE));
         return option;

--- a/demo/src/test/java/test/Test.java
+++ b/demo/src/test/java/test/Test.java
@@ -1,14 +1,18 @@
 package test;
 
+import com.formdev.flatlaf.FlatClientProperties;
 import com.formdev.flatlaf.fonts.roboto.FlatRobotoFont;
 import com.formdev.flatlaf.themes.FlatMacLightLaf;
 import net.miginfocom.swing.MigLayout;
 import raven.extras.LightDarkButton;
 import raven.modal.ModalDialog;
 import raven.modal.component.SimpleModalBorder;
+import raven.modal.demo.forms.FormResponsiveLayout;
 import raven.modal.demo.simple.SimpleInputForms;
 import raven.modal.demo.simple.SimpleInputForms2;
+import raven.modal.demo.system.Form;
 import raven.modal.option.BorderOption;
+import raven.modal.option.Option;
 
 import javax.swing.*;
 import java.awt.*;
@@ -17,12 +21,14 @@ public class Test extends JFrame {
 
     public Test() {
         setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        getRootPane().putClientProperty(FlatClientProperties.FULL_WINDOW_CONTENT, true);
         setSize(new Dimension(800, 800));
         setLocationRelativeTo(null);
-        setLayout(new MigLayout("wrap,al center center"));
+        setLayout(new MigLayout("wrap,al center center,fillx"));
         JButton button = new JButton("show");
         ModalDialog.getDefaultOption()
-                .setOpacity(0f)
+                .setBackgroundBlur(Option.BackgroundBlur.SMALL)
+                .setOpacity(0.1f)
                 .getBorderOption()
                 .setBorderWidth(0.5f)
                 .setShadow(BorderOption.Shadow.MEDIUM);
@@ -37,10 +43,14 @@ public class Test extends JFrame {
                 }
             }), "input");
         });
-        add(button);
+        add(button, "split 2");
         LightDarkButton lightDarkButton = new LightDarkButton();
         lightDarkButton.installAutoLafChangeListener();
         add(lightDarkButton);
+
+        Form testForm = new FormResponsiveLayout();
+        testForm.formInit();
+        add(testForm, "grow");
     }
 
     public static void main(String[] args) {

--- a/modal-dialog/src/main/java/raven/modal/ModalDialog.java
+++ b/modal-dialog/src/main/java/raven/modal/ModalDialog.java
@@ -21,7 +21,7 @@ import java.util.Map;
 public class ModalDialog {
 
     private static ModalDialog instance;
-    private final Integer LAYER = JLayeredPane.MODAL_LAYER + 1;
+    public static final Integer LAYER = JLayeredPane.MODAL_LAYER + 1;
     private Map<RootPaneContainer, ModalContainerLayer> map;
     private Option defaultOption;
 

--- a/modal-dialog/src/main/java/raven/modal/component/ModalContainer.java
+++ b/modal-dialog/src/main/java/raven/modal/component/ModalContainer.java
@@ -123,7 +123,7 @@ public class ModalContainer extends JComponent {
         uninstallOption();
     }
 
-    protected void showSnapshot() {
+    public void showSnapshot() {
         modalContainerLayer.showSnapshot();
         Option option = modalController.getOption();
         if (option.getBackgroundBlur().isBlur()) {
@@ -136,7 +136,7 @@ public class ModalContainer extends JComponent {
         }
     }
 
-    protected void hideSnapshot() {
+    public void hideSnapshot() {
         modalContainerLayer.hideSnapshot();
         if (snapshotBlurImage != null) {
             snapshotBlurImage.flush();

--- a/modal-dialog/src/main/java/raven/modal/component/ModalController.java
+++ b/modal-dialog/src/main/java/raven/modal/component/ModalController.java
@@ -109,6 +109,7 @@ public class ModalController extends JPanel {
     }
 
     public void showModal() {
+        FocusManager.getCurrentManager().clearFocusOwner();
         setFocusCycleRoot(true);
         installModalComponent(modal);
         startAnimator(true);
@@ -157,7 +158,6 @@ public class ModalController extends JPanel {
 
                     @Override
                     public void begin() {
-                        modalContainer.showSnapshot();
                         Border border = getBorder();
                         if (border != null) {
                             snapshotsImage = ImageSnapshots.createSnapshotsImage(panelSlider, ModalController.this, getBorder());
@@ -194,6 +194,7 @@ public class ModalController extends JPanel {
             } else {
                 animated = 1;
             }
+            modalContainer.showSnapshot();
             animator.start();
         } else {
             this.showing = show;
@@ -204,6 +205,7 @@ public class ModalController extends JPanel {
                 modalOpened();
             } else {
                 animated = 0;
+                modalContainer.hideSnapshot();
                 remove();
             }
         }
@@ -264,6 +266,23 @@ public class ModalController extends JPanel {
             } else {
                 super.paint(g);
             }
+        }
+    }
+
+    /**
+     * Paint for snapshot background
+     */
+    protected void paintSnapshot(Graphics g) {
+        g.translate(getX(), getY());
+        if (snapshotsImage != null) {
+            g.drawImage(snapshotsImage, 0, 0, null);
+        } else {
+            // print border because method `printComponents()` don't paint it
+            Border border = getBorder();
+            if (border != null) {
+                border.paintBorder(this, g, 0, 0, getWidth(), getHeight());
+            }
+            printComponents(g);
         }
     }
 

--- a/modal-dialog/src/main/java/raven/modal/option/Option.java
+++ b/modal-dialog/src/main/java/raven/modal/option/Option.java
@@ -25,6 +25,10 @@ public class Option {
         return backgroundClickType;
     }
 
+    public BackgroundBlur getBackgroundBlur() {
+        return backgroundBlur;
+    }
+
     public boolean isAnimationEnabled() {
         return animationEnabled;
     }
@@ -56,6 +60,7 @@ public class Option {
     private LayoutOption layoutOption = LayoutOption.getDefault();
     private BorderOption borderOption = BorderOption.getDefault();
     private BackgroundClickType backgroundClickType = BackgroundClickType.CLOSE_MODAL;
+    public BackgroundBlur backgroundBlur = BackgroundBlur.NONE;
     private boolean animationEnabled = true;
     private boolean closeOnPressedEscape = true;
     private Color backgroundLight;
@@ -64,10 +69,11 @@ public class Option {
     private int duration = 350;
     private int sliderDuration = 400;
 
-    private Option(LayoutOption layoutOption, BorderOption borderOption, BackgroundClickType backgroundClickType, boolean animationEnabled, boolean closeOnPressedEscape, Color backgroundLight, Color backgroundDark, float opacity, int duration, int sliderDuration) {
+    private Option(LayoutOption layoutOption, BorderOption borderOption, BackgroundClickType backgroundClickType, BackgroundBlur backgroundBlur, boolean animationEnabled, boolean closeOnPressedEscape, Color backgroundLight, Color backgroundDark, float opacity, int duration, int sliderDuration) {
         this.layoutOption = layoutOption;
         this.borderOption = borderOption;
         this.backgroundClickType = backgroundClickType;
+        this.backgroundBlur = backgroundBlur;
         this.animationEnabled = animationEnabled;
         this.closeOnPressedEscape = closeOnPressedEscape;
         this.backgroundLight = backgroundLight;
@@ -87,6 +93,11 @@ public class Option {
 
     public Option setBackgroundClickType(BackgroundClickType backgroundClickType) {
         this.backgroundClickType = backgroundClickType;
+        return this;
+    }
+
+    public Option setBackgroundBlur(BackgroundBlur backgroundBlur) {
+        this.backgroundBlur = backgroundBlur;
         return this;
     }
 
@@ -131,7 +142,30 @@ public class Option {
         CLOSE_MODAL, BLOCK, NONE
     }
 
+    public enum BackgroundBlur {
+        NONE(0),
+        SMALL(2),
+        MEDIUM(3),
+        LARGE(4),
+        EXTRA_LARGE(5),
+        DOUBLE_EXTRA_LARGE(6);
+
+        private final int radius;
+
+        BackgroundBlur(int radius) {
+            this.radius = radius;
+        }
+
+        public int getRadius() {
+            return radius;
+        }
+
+        public boolean isBlur() {
+            return radius > 1;
+        }
+    }
+
     public Option copy() {
-        return new Option(layoutOption.copy(), borderOption.copy(), backgroundClickType, animationEnabled, closeOnPressedEscape, backgroundLight == null ? null : new Color(backgroundLight.getRGB()), backgroundDark == null ? null : new Color(backgroundDark.getRGB()), opacity, duration, sliderDuration);
+        return new Option(layoutOption.copy(), borderOption.copy(), backgroundClickType, backgroundBlur, animationEnabled, closeOnPressedEscape, backgroundLight == null ? null : new Color(backgroundLight.getRGB()), backgroundDark == null ? null : new Color(backgroundDark.getRGB()), opacity, duration, sliderDuration);
     }
 }

--- a/modal-dialog/src/main/java/raven/modal/slider/PanelSlider.java
+++ b/modal-dialog/src/main/java/raven/modal/slider/PanelSlider.java
@@ -118,6 +118,7 @@ public class PanelSlider extends JLayeredPane {
 
                 @Override
                 public void end() {
+                    modalContainer.hideSnapshot();
                     setVisible(false);
                     component.setVisible(true);
                     animatedLayout.reset();
@@ -146,6 +147,7 @@ public class PanelSlider extends JLayeredPane {
             repaint();
             setVisible(true);
             animator.setDuration(duration);
+            modalContainer.showSnapshot();
             animator.start();
         }
 

--- a/modal-dialog/src/main/java/raven/modal/utils/BlurImageUtils.java
+++ b/modal-dialog/src/main/java/raven/modal/utils/BlurImageUtils.java
@@ -1,0 +1,73 @@
+package raven.modal.utils;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.awt.image.ConvolveOp;
+import java.awt.image.Kernel;
+import java.awt.image.VolatileImage;
+
+/**
+ * @author Raven
+ */
+public class BlurImageUtils {
+
+    public static BufferedImage applyGaussianBlur(VolatileImage image, int radius) {
+        BufferedImage bufferedImage = toBufferedImage(image);
+        image.flush();
+        return applyGaussianBlur(bufferedImage, radius);
+    }
+
+    /**
+     * Applies a separable gaussian blur by blurring horizontally and vertically in two passes
+     */
+    public static BufferedImage applyGaussianBlur(BufferedImage image, int radius) {
+        // generate a 1D gaussian kernel
+        float[] kernelData = createGaussianKernel(radius);
+
+        // blur horizontally
+        BufferedImage tempImage = new BufferedImage(image.getWidth(), image.getHeight(), image.getType());
+        ConvolveOp horizontalBlur = new ConvolveOp(new Kernel(kernelData.length, 1, kernelData));
+        horizontalBlur.filter(image, tempImage);
+
+        // blur vertically
+        BufferedImage blurredImage = new BufferedImage(image.getWidth(), image.getHeight(), image.getType());
+        ConvolveOp verticalBlur = new ConvolveOp(new Kernel(1, kernelData.length, kernelData));
+        verticalBlur.filter(tempImage, blurredImage);
+
+        image.flush();
+        return blurredImage;
+    }
+
+    /**
+     * Method to create BufferedImage from VolatileImage
+     */
+    public static BufferedImage toBufferedImage(VolatileImage vImage) {
+        BufferedImage bImage = new BufferedImage(vImage.getWidth(), vImage.getHeight(), BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g2d = bImage.createGraphics();
+        g2d.drawImage(vImage, 0, 0, null);
+        g2d.dispose();
+        return bImage;
+    }
+
+    /**
+     * Generates a 1D gaussian kernel with a specified radius
+     */
+    private static float[] createGaussianKernel(int radius) {
+        int size = radius * 2 + 1;
+        float[] kernel = new float[size];
+        float sigma = radius / 2.0f;
+        float sum = 0f;
+
+        for (int i = 0; i < size; i++) {
+            int x = i - radius;
+            kernel[i] = (float) Math.exp(-0.5 * (x * x) / (sigma * sigma));
+            sum += kernel[i];
+        }
+
+        // normalize the kernel so the sum is 1
+        for (int i = 0; i < size; i++) {
+            kernel[i] /= sum;
+        }
+        return kernel;
+    }
+}


### PR DESCRIPTION
This PR add new blur background option

### Example

``` java
// create border option
Option option = ModalDialog.createOption();

// apply small blur
option.setBackgroundBlur(Option.BackgroundBlur.SMALL);
```
blur enum available: `NONE`, `SMALL`, `MEDIUM`, `LARGE`, `EXTRA_LARGE`, `DOUBLE_EXTRA_LARGE`

### Option added in demo

![2024-11-01_232436](https://github.com/user-attachments/assets/a482eb4d-685b-4f54-a236-cc1b18110861)

### Screenshot

![2024-11-01_233954](https://github.com/user-attachments/assets/afac6c6b-da1a-4382-8a0a-c38c66a98444)
