### PR TITLE
Modal and Toast: add `heavyWeight` and `relativeToOwner` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [2.3.0]-SNAPSHOT
+
+### New features and improvements
+
+- Modal dialog and Toast
+    - Add new option `heavyWeight` by default `false` if set to true, the modal and toast will show by create `JWindow`
+    - Add new layout option `relativeToOwner` by default `false` if set to true, the location modal and toast will show
+      relative to the owner component
+
+### Fixed bugs
+
+- Modal dialog
+    - Fixed `borderWidth`
+        - fixed border not paint when value `1` and round border is active
+        - fixed border not paint when value `0.5f`
+
+## Demo
+
+- Create dashboard form using `JFreeChart`
+
 ## [2.2.0] - 2024-12-31
 
 ### New features and improvements

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Add the snapshot version
 <dependency>
     <groupId>io.github.dj-raven</groupId>
     <artifactId>modal-dialog</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.dj-raven</groupId>
         <artifactId>swing-modal-dialog</artifactId>
-        <version>2.2.0</version>
+        <version>2.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>demo</artifactId>

--- a/demo/src/main/java/raven/modal/demo/Demo.java
+++ b/demo/src/main/java/raven/modal/demo/Demo.java
@@ -13,7 +13,7 @@ import java.awt.*;
 
 public class Demo extends JFrame {
 
-    public static final String DEMO_VERSION = "2.2.0";
+    public static final String DEMO_VERSION = "2.3.0-SNAPSHOT";
 
     public Demo() {
         init();

--- a/demo/src/main/java/raven/modal/demo/component/EmptyModalBorder.java
+++ b/demo/src/main/java/raven/modal/demo/component/EmptyModalBorder.java
@@ -33,7 +33,7 @@ public class EmptyModalBorder extends Modal {
         return new ModalController(this) {
             @Override
             public void close() {
-                getController().getModalContainer().closeModal();
+                getController().closeModal();
             }
         };
     }

--- a/demo/src/main/java/raven/modal/demo/forms/FormModal.java
+++ b/demo/src/main/java/raven/modal/demo/forms/FormModal.java
@@ -116,6 +116,7 @@ public class FormModal extends Form {
         chOpacity = new JCheckBox("Background opacity");
         chScale = new JCheckBox("Animate scale");
         chHeavyWeight = new JCheckBox("Heavy Weight");
+        chRelativeToOwner = new JCheckBox("Relative to owner");
 
         // event
         chAnimation.addActionListener(e -> {
@@ -133,6 +134,7 @@ public class FormModal extends Form {
         panel.add(chOpacity);
         panel.add(chScale);
         panel.add(chHeavyWeight);
+        panel.add(chRelativeToOwner);
 
         return panel;
     }
@@ -247,7 +249,8 @@ public class FormModal extends Form {
         option.getBorderOption()
                 .setBorderWidth(chBorder.isSelected() ? 1f : 0)
                 .setShadow(chShadow.isSelected() ? BorderOption.Shadow.MEDIUM : BorderOption.Shadow.NONE);
-        option.getLayoutOption().setLocation(h, v);
+        option.getLayoutOption().setLocation(h, v)
+                .setRelativeToOwner(chRelativeToOwner.isSelected());
         if (scale != 0) {
             option.getLayoutOption().setAnimateDistance(0, 0)
                     .setAnimateScale(scale);
@@ -275,6 +278,7 @@ public class FormModal extends Form {
     private JCheckBox chOpacity;
     private JCheckBox chScale;
     private JCheckBox chHeavyWeight;
+    private JCheckBox chRelativeToOwner;
 
     // background click option
     private JRadioButton jrClose;

--- a/demo/src/main/java/raven/modal/demo/forms/FormModal.java
+++ b/demo/src/main/java/raven/modal/demo/forms/FormModal.java
@@ -115,6 +115,7 @@ public class FormModal extends Form {
         chShadow = new JCheckBox("Shadow border");
         chOpacity = new JCheckBox("Background opacity");
         chScale = new JCheckBox("Animate scale");
+        chHeavyWeight = new JCheckBox("Heavy Weight");
 
         // event
         chAnimation.addActionListener(e -> {
@@ -131,6 +132,7 @@ public class FormModal extends Form {
         panel.add(chShadow);
         panel.add(chOpacity);
         panel.add(chScale);
+        panel.add(chHeavyWeight);
 
         return panel;
     }
@@ -216,9 +218,6 @@ public class FormModal extends Form {
     }
 
     private void showModalSlide(Option option) {
-        option.getLayoutOption()
-                .setOnTop(true);
-
         final String id = "input";
         ModalDialog.showModal(this, new SimpleModalBorder(
                 new SimpleInputForms(), "Sample Input Forms", SimpleModalBorder.YES_NO_CANCEL_OPTION,
@@ -243,7 +242,8 @@ public class FormModal extends Form {
         option.setAnimationEnabled(chAnimation.isSelected())
                 .setCloseOnPressedEscape(chCloseOnPressedEscape.isSelected())
                 .setBackgroundClickType(backgroundClickType)
-                .setOpacity(chOpacity.isSelected() ? 0.5f : 0);
+                .setOpacity(chOpacity.isSelected() ? 0.5f : 0)
+                .setHeavyWeight(chHeavyWeight.isSelected());
         option.getBorderOption()
                 .setBorderWidth(chBorder.isSelected() ? 1f : 0)
                 .setShadow(chShadow.isSelected() ? BorderOption.Shadow.MEDIUM : BorderOption.Shadow.NONE);
@@ -274,6 +274,7 @@ public class FormModal extends Form {
     private JCheckBox chShadow;
     private JCheckBox chOpacity;
     private JCheckBox chScale;
+    private JCheckBox chHeavyWeight;
 
     // background click option
     private JRadioButton jrClose;

--- a/demo/src/main/java/raven/modal/demo/forms/FormToast.java
+++ b/demo/src/main/java/raven/modal/demo/forms/FormToast.java
@@ -106,6 +106,8 @@ public class FormToast extends Form {
         chPauseDelayOnHover = new JCheckBox("Pause delay on hover");
         chAutoClose = new JCheckBox("Auto close");
         chCloseOnClick = new JCheckBox("Close on click");
+        chHeavyWeight = new JCheckBox("Heavy Weight");
+        chRelativeToOwner = new JCheckBox("Relative to owner");
         JCheckBox chReverseOrder = new JCheckBox("Reverse Order");
 
         chAnimation.setSelected(true);
@@ -118,6 +120,8 @@ public class FormToast extends Form {
         panel.add(chPauseDelayOnHover);
         panel.add(chAutoClose);
         panel.add(chCloseOnClick);
+        panel.add(chHeavyWeight);
+        panel.add(chRelativeToOwner);
         panel.add(chReverseOrder);
 
         return panel;
@@ -293,10 +297,12 @@ public class FormToast extends Form {
         option.setAnimationEnabled(chAnimation.isSelected())
                 .setPauseDelayOnHover(chPauseDelayOnHover.isSelected())
                 .setAutoClose(chAutoClose.isSelected())
-                .setCloseOnClick(chCloseOnClick.isSelected());
+                .setCloseOnClick(chCloseOnClick.isSelected())
+                .setHeavyWeight(chHeavyWeight.isSelected());
 
         option.getLayoutOption()
-                .setLocation(ToastLocation.from(h, v));
+                .setLocation(ToastLocation.from(h, v))
+                .setRelativeToOwner(chRelativeToOwner.isSelected());
         option.getStyle().setBackgroundType(backgroundType)
                 .setBorderType(borderType)
                 .setShowLabel(chShowLabel.isSelected())
@@ -321,6 +327,8 @@ public class FormToast extends Form {
     private JCheckBox chPauseDelayOnHover;
     private JCheckBox chAutoClose;
     private JCheckBox chCloseOnClick;
+    private JCheckBox chHeavyWeight;
+    private JCheckBox chRelativeToOwner;
 
     // style background
     private JRadioButton jrBackgroundDefault;

--- a/modal-dialog/pom.xml
+++ b/modal-dialog/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.dj-raven</groupId>
     <artifactId>modal-dialog</artifactId>
-    <version>2.2.0</version>
+    <version>2.3.0-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>

--- a/modal-dialog/src/main/java/raven/modal/Drawer.java
+++ b/modal-dialog/src/main/java/raven/modal/Drawer.java
@@ -72,7 +72,7 @@ public class Drawer {
         }
         if (!visible) {
             if (ModalDialog.isIdExist(DRAWER_ID)) {
-                ModalDialog.closeModalAsRemove(DRAWER_ID);
+                ModalDialog.closeModalImmediately(DRAWER_ID);
             }
         }
     }

--- a/modal-dialog/src/main/java/raven/modal/ModalDialog.java
+++ b/modal-dialog/src/main/java/raven/modal/ModalDialog.java
@@ -1,19 +1,14 @@
 package raven.modal;
 
-import raven.modal.component.Modal;
-import raven.modal.component.ModalContainer;
-import raven.modal.component.ModalContainerLayer;
+import raven.modal.component.*;
 import raven.modal.drawer.DrawerLayoutResponsive;
 import raven.modal.drawer.DrawerPanel;
 import raven.modal.layout.FrameModalLayout;
 import raven.modal.layout.FrameToastLayout;
 import raven.modal.option.Option;
-import raven.modal.utils.ModalUtils;
 
 import javax.swing.*;
 import java.awt.*;
-import java.awt.event.WindowStateListener;
-import java.beans.PropertyChangeListener;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -56,44 +51,39 @@ public class ModalDialog {
             throw new IllegalArgumentException("id '" + id + "' already exist");
         }
         SwingUtilities.invokeLater(() -> {
-            ModalContainerLayer modalContainerLayer = getInstance().getModalContainerLayered(getRootPaneContainer(owner));
-            modalContainerLayer.addModal(owner, modal, option, id);
-            modalContainerLayer.repaint();
-            modalContainerLayer.revalidate();
+            boolean isHeavyWeight = option.isHeavyWeight();
+            getInstance().getModalContainer(owner, isHeavyWeight).addModal(owner, modal, option, id);
         });
     }
 
     public static void pushModal(Modal modal, String id) {
-        RootPaneContainer rootPaneContainer = getInstance().getRootPaneContainerById(id);
-        if (rootPaneContainer == null) {
-            throw new IllegalArgumentException("id '" + id + "' not found");
-        }
-        ModalContainerLayer modalContainerLayer = getInstance().getModalContainerLayered(rootPaneContainer);
-        modalContainerLayer.pushModal(modal, id);
+        getInstance().getModalContainerById(id).pushModal(modal, id);
     }
 
     public static void popModel(String id) {
-        RootPaneContainer rootPaneContainer = getInstance().getRootPaneContainerById(id);
-        if (rootPaneContainer == null) {
-            throw new IllegalArgumentException("id '" + id + "' not found");
-        }
-        ModalContainerLayer modalContainerLayer = getInstance().getModalContainerLayered(rootPaneContainer);
-        modalContainerLayer.popModal(id);
+        getInstance().getModalContainerById(id).popModal(id);
     }
 
     public static void closeModal(String id) {
-        RootPaneContainer rootPaneContainer = getInstance().getRootPaneContainerById(id);
-        if (rootPaneContainer == null) {
-            throw new IllegalArgumentException("id '" + id + "' not found");
-        }
-        ModalContainerLayer modalContainerLayer = getInstance().getModalContainerLayered(rootPaneContainer);
-        modalContainerLayer.closeModal(id);
+        getInstance().getModalContainerById(id).closeModal(id);
     }
 
     public static void closeAllModal() {
-        for (Map.Entry<RootPaneContainer, ModalContainerLayer> entry : getInstance().map.entrySet()) {
-            entry.getValue().closeAllModal();
-        }
+        getInstance().map.values().forEach(con -> {
+            con.closeAllModal();
+        });
+        ModalHeavyWeight.getInstance().closeAllModal();
+    }
+
+    public static void closeModalImmediately(String id) {
+        getInstance().getModalContainerById(id).closeModalImmediately(id);
+    }
+
+    public static void closeAllModalImmediately() {
+        getInstance().map.values().forEach(con -> {
+            con.closeAllModalImmediately();
+        });
+        ModalHeavyWeight.getInstance().closeAllModalImmediately();
     }
 
     public static boolean isIdExist(String id) {
@@ -102,7 +92,7 @@ public class ModalDialog {
                 return true;
             }
         }
-        return false;
+        return ModalHeavyWeight.getInstance().isIdExist(id);
     }
 
     public static void setDefaultOption(Option option) {
@@ -137,15 +127,6 @@ public class ModalDialog {
         return modalContainerLayer.addModalWithoutShowing(null, modal, option, id);
     }
 
-    protected static void closeModalAsRemove(String id) {
-        RootPaneContainer rootPaneContainer = getInstance().getRootPaneContainerById(id);
-        if (rootPaneContainer == null) {
-            throw new IllegalArgumentException("id '" + id + "' not found");
-        }
-        ModalContainerLayer modalContainerLayer = getInstance().getModalContainerLayered(rootPaneContainer);
-        modalContainerLayer.closeAsRemove(id);
-    }
-
     protected static RootPaneContainer getRootPaneContainer(Component component) {
         if (component == null) {
             throw new IllegalArgumentException("parent component must not null");
@@ -156,10 +137,10 @@ public class ModalDialog {
         return getRootPaneContainer(component.getParent());
     }
 
-    private RootPaneContainer getRootPaneContainerById(String id) {
+    private ModalContainerLayer getRootPaneContainerById(String id) {
         for (Map.Entry<RootPaneContainer, ModalContainerLayer> entry : map.entrySet()) {
             if (entry.getValue().checkId(id)) {
-                return entry.getKey();
+                return entry.getValue();
             }
         }
         return null;
@@ -180,7 +161,7 @@ public class ModalDialog {
             modalContainerLayer = createModalContainerLayered(rootPaneContainer);
 
             // add modal container layered to window layeredPane
-            windowLayeredPane.add(modalContainerLayer, LAYER);
+            windowLayeredPane.add(modalContainerLayer.getLayeredPane(), LAYER);
 
             // create snapshot layered
             Component snapshot = modalContainerLayer.createLayeredSnapshot();
@@ -188,7 +169,7 @@ public class ModalDialog {
             windowLayeredPane.add(snapshot, LAYER - 1);
 
             // set custom layout to window layeredPane
-            FrameModalLayout frameModalLayout = new FrameModalLayout(modalContainerLayer, rootPaneContainer.getContentPane(), snapshot);
+            FrameModalLayout frameModalLayout = new FrameModalLayout(modalContainerLayer.getLayeredPane(), rootPaneContainer.getContentPane(), snapshot);
             LayoutManager oldLayout = windowLayeredPane.getLayout();
             windowLayeredPane.setLayout(frameModalLayout);
             windowLayeredPane.doLayout();
@@ -202,69 +183,34 @@ public class ModalDialog {
             // store modal container layered to map
             map.put(rootPaneContainer, modalContainerLayer);
 
-            // install property to remove the root pane map after windows removed
-            modalContainerLayer.setPropertyData(installProperty(rootPaneContainer.getRootPane()));
-            modalContainerLayer.setWindowListener(installWindowStateChanged(rootPaneContainer));
+            // install property to windows
+            modalContainerLayer.installWindowListener();
         }
         return modalContainerLayer;
     }
 
-    private Object installProperty(JRootPane rootPane) {
-        PropertyChangeListener propertyChangeListener = e -> {
-            if (e.getNewValue() == null && e.getOldValue() instanceof RootPaneContainer) {
-                uninstall((RootPaneContainer) e.getOldValue());
-            }
-        };
-        rootPane.addPropertyChangeListener("ancestor", propertyChangeListener);
-        return propertyChangeListener;
-    }
-
-    private WindowStateListener installWindowStateChanged(RootPaneContainer rootPane) {
-        return ModalUtils.installWindowStateListener(rootPane, e -> {
-            if (e.getNewState() == 6 || e.getNewState() == 0) {
-                SwingUtilities.invokeLater(() -> {
-                    if (map.containsKey(rootPane)) {
-                        map.get(rootPane).getSetModalContainer().forEach(container -> container.revalidate());
-                    }
-                });
-            }
-        });
-    }
-
-    private void uninstall(RootPaneContainer rootPaneContainer) {
-        if (map.containsKey(rootPaneContainer)) {
-            ModalContainerLayer modalContainerLayer = map.get(rootPaneContainer);
-            JLayeredPane windowLayeredPane = rootPaneContainer.getLayeredPane();
-            rootPaneContainer.getRootPane().removePropertyChangeListener("ancestor", (PropertyChangeListener) modalContainerLayer.getPropertyData());
-            ModalUtils.uninstallWindowStateListener(rootPaneContainer, modalContainerLayer.getWindowListener());
-
-            // uninstall layout
-            LayoutManager oldLayout = windowLayeredPane.getLayout();
-            if (oldLayout != null) {
-                if (oldLayout instanceof FrameModalLayout) {
-                    FrameModalLayout frameModalLayout = (FrameModalLayout) oldLayout;
-                    if (frameModalLayout.getOldOtherComponentLayout() != null) {
-                        windowLayeredPane.setLayout(frameModalLayout.getOldOtherComponentLayout());
-                    } else {
-                        windowLayeredPane.setLayout(null);
-                    }
-                }
-            }
-
-            // remove
-            map.remove(rootPaneContainer);
-            windowLayeredPane.remove(modalContainerLayer);
-            Component componentSnapshot = modalContainerLayer.getComponentSnapshot();
-            if (componentSnapshot != null) {
-                windowLayeredPane.remove(modalContainerLayer.getComponentSnapshot());
-            }
-            modalContainerLayer.remove();
-        }
-    }
-
     private ModalContainerLayer createModalContainerLayered(RootPaneContainer rootPaneContainer) {
-        ModalContainerLayer layeredPane = new ModalContainerLayer(rootPaneContainer);
-        layeredPane.setVisible(false);
+        ModalContainerLayer layeredPane = new ModalContainerLayer(map, rootPaneContainer);
+        layeredPane.getLayeredPane().setVisible(false);
         return layeredPane;
+    }
+
+    private AbstractModalContainerLayer getModalContainerById(String id) {
+        ModalContainerLayer modalContainer = getRootPaneContainerById(id);
+        if (modalContainer != null) {
+            return modalContainer;
+        }
+        ModalHeavyWeightContainerLayer modalHeavyWeight = ModalHeavyWeight.getInstance().getModalHeavyWeightContainerById(id);
+        if (modalHeavyWeight != null) {
+            return modalHeavyWeight;
+        }
+        throw new IllegalArgumentException("id '" + id + "' not found");
+    }
+
+    private AbstractModalContainerLayer getModalContainer(Component owner, boolean isHeavyWeight) {
+        if (isHeavyWeight) {
+            return ModalHeavyWeight.getInstance().getModalHeavyWeightContainer(owner);
+        }
+        return getModalContainerLayered(getRootPaneContainer(owner));
     }
 }

--- a/modal-dialog/src/main/java/raven/modal/ModalDialog.java
+++ b/modal-dialog/src/main/java/raven/modal/ModalDialog.java
@@ -87,8 +87,8 @@ public class ModalDialog {
     }
 
     public static boolean isIdExist(String id) {
-        for (Map.Entry<RootPaneContainer, ModalContainerLayer> entry : getInstance().map.entrySet()) {
-            if (entry.getValue().checkId(id)) {
+        for (ModalContainerLayer con : getInstance().map.values()) {
+            if (con.checkId(id)) {
                 return true;
             }
         }
@@ -138,9 +138,9 @@ public class ModalDialog {
     }
 
     private ModalContainerLayer getRootPaneContainerById(String id) {
-        for (Map.Entry<RootPaneContainer, ModalContainerLayer> entry : map.entrySet()) {
-            if (entry.getValue().checkId(id)) {
-                return entry.getValue();
+        for (ModalContainerLayer con : map.values()) {
+            if (con.checkId(id)) {
+                return con;
             }
         }
         return null;

--- a/modal-dialog/src/main/java/raven/modal/component/AbstractModalContainerLayer.java
+++ b/modal-dialog/src/main/java/raven/modal/component/AbstractModalContainerLayer.java
@@ -1,0 +1,114 @@
+package raven.modal.component;
+
+import raven.modal.layout.FullContentLayout;
+import raven.modal.option.Option;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * @author Raven
+ */
+public abstract class AbstractModalContainerLayer {
+
+    protected final Set<ModalContainer> containers;
+    protected final JLayeredPane layeredPane;
+
+    public AbstractModalContainerLayer() {
+        containers = new HashSet<>();
+        layeredPane = new JLayeredPane();
+        layeredPane.setLayout(new FullContentLayout());
+    }
+
+    protected void animatedBegin() {
+    }
+
+    protected void animatedEnd() {
+    }
+
+    public abstract void showContainer(boolean show);
+
+    public void removeContainer(ModalContainer container) {
+        containers.remove(container);
+        layeredPane.remove(container);
+        layeredPane.repaint();
+        layeredPane.revalidate();
+    }
+
+    public void addModal(Component owner, Modal modal, Option option, String id) {
+        addModalWithoutShowing(owner, modal, option, id)
+                .showModal();
+    }
+
+    public ModalContainer addModalWithoutShowing(Component owner, Modal modal, Option option, String id) {
+        ModalContainer modalContainer = new ModalContainer(this, owner, option, id);
+        layeredPane.setLayer(modalContainer, JLayeredPane.MODAL_LAYER + (option.getLayoutOption().isOnTop() ? 1 : 0));
+        layeredPane.add(modalContainer, 0);
+        modalContainer.initModal(modal);
+        modal.setId(id);
+        containers.add(modalContainer);
+        return modalContainer;
+    }
+
+    public void pushModal(Modal modal, String id) {
+        getModalControllerById(id).getController().pushModal(modal);
+    }
+
+    public void popModal(String id) {
+        getModalControllerById(id).getController().popModal();
+    }
+
+    public void closeModal(String id) {
+        getModalControllerById(id).getController().closeModal();
+    }
+
+    public void closeAllModal() {
+        for (ModalContainer con : containers.toArray(new ModalContainer[containers.size()])) {
+            con.getController().closeModal();
+        }
+    }
+
+    public void closeModalImmediately(String id) {
+        getModalControllerById(id).getController().closeImmediately();
+    }
+
+    public void closeAllModalImmediately() {
+        for (ModalContainer con : containers.toArray(new ModalContainer[containers.size()])) {
+            con.getController().closeImmediately();
+        }
+    }
+
+    public void updateModalLayout() {
+        for (ModalContainer con : containers) {
+            con.revalidate();
+        }
+    }
+
+    public boolean checkId(String id) {
+        for (ModalContainer con : containers) {
+            if (con.getId() != null && con.getId() == id) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private ModalContainer getModalControllerById(String id) {
+        for (ModalContainer con : containers) {
+            if (con.getId() != null && con.getId().equals(id)) {
+                return con;
+            }
+        }
+        throw new IllegalArgumentException("id '" + id + "' not found");
+    }
+
+    public Set<ModalContainer> getContainers() {
+        return containers;
+    }
+
+    public JLayeredPane getLayeredPane() {
+        return layeredPane;
+    }
+}

--- a/modal-dialog/src/main/java/raven/modal/component/AbstractModalController.java
+++ b/modal-dialog/src/main/java/raven/modal/component/AbstractModalController.java
@@ -1,0 +1,173 @@
+package raven.modal.component;
+
+import net.miginfocom.swing.MigLayout;
+import raven.modal.option.BorderOption;
+import raven.modal.option.Option;
+import raven.modal.slider.PanelSlider;
+import raven.modal.slider.SimpleTransition;
+import raven.modal.slider.SliderTransition;
+import raven.modal.utils.ModalUtils;
+
+import javax.swing.*;
+import javax.swing.border.Border;
+import java.awt.*;
+import java.awt.event.MouseAdapter;
+import java.util.Stack;
+import java.util.function.Consumer;
+
+/**
+ * @author Raven
+ */
+public abstract class AbstractModalController extends JPanel implements ControllerAction {
+
+    protected final Option option;
+
+    protected Modal modal;
+    protected PanelSlider panelSlider;
+    protected Stack<Modal> modalStack;
+    protected Consumer onBackAction;
+
+    public AbstractModalController(Option option) {
+        this.option = option;
+        init();
+    }
+
+    private void init() {
+        // create mouse event to block the component
+        addMouseListener(new MouseAdapter() {
+        });
+
+        Insets shadowSize = option.getBorderOption().getShadowSize();
+        int minimumSize = ModalUtils.maximumInsets(shadowSize);
+        setLayout(new MigLayout("fill,insets 0", "[fill," + minimumSize + "::]", "[fill," + minimumSize + "::]"));
+        setOpaque(false);
+
+        panelSlider = new PanelSlider(createSliderLayoutSize());
+        panelSlider.setRequestFocusAfterSlide(true);
+        panelSlider.setUseSlideAsBackground(true);
+        panelSlider.setOpaque(true);
+        initBorder();
+        add(panelSlider);
+    }
+
+    protected void initBorder() {
+        if (option == null) {
+            return;
+        }
+        BorderOption borderOption = option.getBorderOption();
+        Border border = borderOption.createBorder();
+        if (border != null) {
+            setBorder(border);
+        }
+    }
+
+    protected void installModalComponent(Modal modal) {
+        // install the modal component for the first show
+        if (!modal.isInstalled()) {
+            modal.installComponent();
+            modal.setInstalled(true);
+        }
+        onModalComponentInstalled();
+    }
+
+    protected void modalOpened() {
+        SwingUtilities.invokeLater(() -> {
+            initFocus();
+            modal.modalOpened();
+        });
+    }
+
+    protected void initFocus() {
+        modal.requestFocus();
+    }
+
+    private void pushStack(Modal modal) {
+        if (modalStack == null) {
+            modalStack = new Stack<>();
+        }
+        modalStack.push(modal);
+    }
+
+    public void initModal(Modal modal) {
+        modal.setController(this);
+        panelSlider.addSlide(modal, null);
+        this.modal = modal;
+    }
+
+    public void pushModal(Modal modal) {
+        installModalComponent(modal);
+        if (modal instanceof SimpleModalBorder) {
+            SimpleModalBorder simpleModalBorder = (SimpleModalBorder) modal;
+            simpleModalBorder.applyBackButton(getOnBackAction());
+        }
+        pushStack(this.modal);
+        this.modal = modal;
+        modal.setController(this);
+        int sliderDuration = option.getSliderDuration();
+        SliderTransition sliderTransition = sliderDuration > 0 ? SimpleTransition.get(SimpleTransition.SliderType.FORWARD) : null;
+        panelSlider.addSlide(modal, sliderTransition, sliderDuration);
+    }
+
+    @Override
+    public void popModal() {
+        if (modalStack != null && !modalStack.isEmpty()) {
+            Modal component = modalStack.pop();
+            this.modal = component;
+            int sliderDuration = option.getSliderDuration();
+            SliderTransition sliderTransition = sliderDuration > 0 ? SimpleTransition.get(SimpleTransition.SliderType.BACK) : null;
+            panelSlider.addSlide(component, sliderTransition, sliderDuration);
+        }
+    }
+
+    public void addModal() {
+        if (panelSlider != null) {
+            panelSlider.add(modal);
+        }
+    }
+
+    public void showModal() {
+        installModalComponent(modal);
+        onShowing();
+    }
+
+    public void removeModal() {
+        panelSlider.remove(modal);
+    }
+
+    @Override
+    public void updateUI() {
+        super.updateUI();
+        initBorder();
+    }
+
+    @Override
+    public Color getBackground() {
+        if (panelSlider == null) {
+            return super.getBackground();
+        }
+        return panelSlider.getBackground();
+    }
+
+    private Consumer getOnBackAction() {
+        if (onBackAction == null) {
+            onBackAction = o -> {
+                popModal();
+            };
+        }
+        return onBackAction;
+    }
+
+    public Option getOption() {
+        return option;
+    }
+
+    public String getId() {
+        return modal.getId();
+    }
+
+    protected abstract PanelSlider.PaneSliderLayoutSize createSliderLayoutSize();
+
+    protected abstract void onModalComponentInstalled();
+
+    protected abstract void onShowing();
+}

--- a/modal-dialog/src/main/java/raven/modal/component/ControllerAction.java
+++ b/modal-dialog/src/main/java/raven/modal/component/ControllerAction.java
@@ -1,0 +1,11 @@
+package raven.modal.component;
+
+/**
+ * @author Raven
+ */
+public interface ControllerAction {
+
+    void popModal();
+
+    void closeModal();
+}

--- a/modal-dialog/src/main/java/raven/modal/component/HeavyWeightWindowShared.java
+++ b/modal-dialog/src/main/java/raven/modal/component/HeavyWeightWindowShared.java
@@ -1,0 +1,43 @@
+package raven.modal.component;
+
+import java.awt.*;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Raven
+ */
+public class HeavyWeightWindowShared {
+
+    private static HeavyWeightWindowShared instance;
+    private Map<Window, ModalWindow> map;
+
+    public static HeavyWeightWindowShared getInstance() {
+        if (instance == null) {
+            instance = new HeavyWeightWindowShared();
+        }
+        return instance;
+    }
+
+    private HeavyWeightWindowShared() {
+        map = new HashMap<>();
+    }
+
+    public ModalWindow getWindowShared(Window parentWindow) {
+        if (map.containsKey(parentWindow)) {
+            return map.get(parentWindow);
+        }
+        ModalWindow window = createWindow(parentWindow);
+        map.put(parentWindow, window);
+        return window;
+    }
+
+    public void remove(Window window) {
+        map.remove(window);
+    }
+
+    private ModalWindow createWindow(Window parent) {
+        ModalWindow window = new ModalWindow(parent);
+        return window;
+    }
+}

--- a/modal-dialog/src/main/java/raven/modal/component/HeavyWindowAction.java
+++ b/modal-dialog/src/main/java/raven/modal/component/HeavyWindowAction.java
@@ -1,0 +1,11 @@
+package raven.modal.component;
+
+/**
+ * @author Raven
+ */
+public interface HeavyWindowAction {
+
+    void windowRemoved();
+
+    boolean isEmptyItem();
+}

--- a/modal-dialog/src/main/java/raven/modal/component/Modal.java
+++ b/modal-dialog/src/main/java/raven/modal/component/Modal.java
@@ -25,16 +25,16 @@ public abstract class Modal extends JPanel {
         this.installed = installed;
     }
 
-    public ModalController getController() {
+    public ControllerAction getController() {
         return controller;
     }
 
-    public void setController(ModalController controller) {
+    public void setController(ControllerAction controller) {
         this.controller = controller;
         controllerInit();
     }
 
-    private ModalController controller;
+    private ControllerAction controller;
     private String id;
     private boolean installed;
 

--- a/modal-dialog/src/main/java/raven/modal/component/ModalBorderAction.java
+++ b/modal-dialog/src/main/java/raven/modal/component/ModalBorderAction.java
@@ -9,8 +9,7 @@ public interface ModalBorderAction {
 
     void doAction(int action);
 
-
-    public static ModalBorderAction getModalBorderAction(Component com) {
+    static ModalBorderAction getModalBorderAction(Component com) {
         if (com == null) {
             return null;
         }

--- a/modal-dialog/src/main/java/raven/modal/component/ModalContainer.java
+++ b/modal-dialog/src/main/java/raven/modal/component/ModalContainer.java
@@ -24,15 +24,21 @@ public class ModalContainer extends JComponent {
         return modalLayout;
     }
 
+    public Component getOwner() {
+        return owner;
+    }
+
     private final String id;
     private ModalContainerLayer modalContainerLayer;
+    private Component owner;
     private ModalController modalController;
     private MouseListener mouseListener;
     private ActionListener escapeAction;
     private ModalLayout modalLayout;
 
-    public ModalContainer(ModalContainerLayer modalContainerLayer, Option option, String id) {
+    public ModalContainer(ModalContainerLayer modalContainerLayer, Component owner, Option option, String id) {
         this.modalContainerLayer = modalContainerLayer;
+        this.owner = owner;
         this.id = id;
         init(modalContainerLayer, option);
     }

--- a/modal-dialog/src/main/java/raven/modal/component/ModalContainer.java
+++ b/modal-dialog/src/main/java/raven/modal/component/ModalContainer.java
@@ -46,7 +46,6 @@ public class ModalContainer extends JComponent {
         modalController = new ModalController(modalContainerLayer, this, option);
         modalLayout = new ModalLayout(modalController, option.getLayoutOption());
         setLayout(modalLayout);
-        installOption(option);
         add(modalController);
     }
 
@@ -89,6 +88,7 @@ public class ModalContainer extends JComponent {
     public void showModal() {
         modalController.showModal();
         modalContainerLayer.showContainer(true);
+        installOption(modalController.getOption());
     }
 
     public ModalController getController() {
@@ -106,17 +106,30 @@ public class ModalContainer extends JComponent {
 
     @Override
     protected void paintComponent(Graphics g) {
-        Graphics2D g2 = (Graphics2D) g.create();
-        g2.setColor(getBackgroundColor());
-        float opacity = modalController.getOption().getOpacity() * modalController.getAnimated();
+        float opacity = modalController.getOption().getOpacity();
+        Option opt = modalController.getOption();
+        if (opt.isHeavyWeight()) {
+            if (opt.getBackgroundClickType() == Option.BackgroundClickType.NONE) {
+                if (opacity != 0) {
+                    opacity = 0;
+                }
+            } else if (opt.getBackgroundClickType() != Option.BackgroundClickType.NONE && opacity == 0) {
+                opacity = 0.01f;
+            }
+        }
+        opacity = opacity * modalController.getAnimated();
         if (opacity > 1) {
             opacity = 1;
         } else if (opacity < 0) {
             opacity = 0;
         }
-        g2.setComposite(AlphaComposite.SrcOver.derive(opacity));
-        g2.fill(new Rectangle2D.Double(0, 0, getWidth(), getHeight()));
-        g2.dispose();
+        if (opacity > 0) {
+            Graphics2D g2 = (Graphics2D) g.create();
+            g2.setColor(getBackgroundColor());
+            g2.setComposite(AlphaComposite.SrcOver.derive(opacity));
+            g2.fill(new Rectangle2D.Double(0, 0, getWidth(), getHeight()));
+            g2.dispose();
+        }
         super.paintComponent(g);
     }
 

--- a/modal-dialog/src/main/java/raven/modal/component/ModalContainerLayer.java
+++ b/modal-dialog/src/main/java/raven/modal/component/ModalContainerLayer.java
@@ -8,6 +8,7 @@ import raven.modal.option.Option;
 
 import javax.swing.*;
 import java.awt.*;
+import java.awt.event.WindowStateListener;
 import java.awt.image.VolatileImage;
 import java.util.HashSet;
 import java.util.Set;
@@ -24,6 +25,7 @@ public class ModalContainerLayer extends JLayeredPane {
     private JLayeredPane layeredSnapshot;
     private DrawerLayoutResponsive drawerLayoutResponsive;
     private Object propertyData;
+    private WindowStateListener windowListener;
 
     public ModalContainerLayer(RootPaneContainer rootPaneContainer) {
         this.rootPaneContainer = rootPaneContainer;
@@ -35,12 +37,12 @@ public class ModalContainerLayer extends JLayeredPane {
         setLayout(new FullContentLayout());
     }
 
-    public void addModal(Modal modal, Option option, String id) {
-        addModalWithoutShowing(modal, option, id).showModal();
+    public void addModal(Component owner, Modal modal, Option option, String id) {
+        addModalWithoutShowing(owner, modal, option, id).showModal();
     }
 
-    public ModalContainer addModalWithoutShowing(Modal modal, Option option, String id) {
-        ModalContainer modalContainer = new ModalContainer(this, option, id);
+    public ModalContainer addModalWithoutShowing(Component owner, Modal modal, Option option, String id) {
+        ModalContainer modalContainer = new ModalContainer(this, owner, option, id);
         setLayer(modalContainer, JLayeredPane.MODAL_LAYER + (option.getLayoutOption().isOnTop() ? 1 : 0));
         add(modalContainer, 0);
         modalContainer.addModal(modal);
@@ -219,6 +221,14 @@ public class ModalContainerLayer extends JLayeredPane {
         this.propertyData = propertyData;
     }
 
+    public WindowStateListener getWindowListener() {
+        return windowListener;
+    }
+
+    public void setWindowListener(WindowStateListener windowListener) {
+        this.windowListener = windowListener;
+    }
+
     public Component getComponentSnapshot() {
         return componentSnapshot;
     }
@@ -230,5 +240,6 @@ public class ModalContainerLayer extends JLayeredPane {
         layeredSnapshot = null;
         drawerLayoutResponsive = null;
         propertyData = null;
+        windowListener = null;
     }
 }

--- a/modal-dialog/src/main/java/raven/modal/component/ModalHeavyWeight.java
+++ b/modal-dialog/src/main/java/raven/modal/component/ModalHeavyWeight.java
@@ -1,0 +1,79 @@
+package raven.modal.component;
+
+import raven.modal.option.Option;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Raven
+ */
+public class ModalHeavyWeight {
+
+    private static ModalHeavyWeight instance;
+    private Map<Window, ModalHeavyWeightContainerLayer> map;
+
+    private ModalHeavyWeight() {
+        map = new HashMap<>();
+    }
+
+    public static ModalHeavyWeight getInstance() {
+        if (instance == null) {
+            instance = new ModalHeavyWeight();
+        }
+        return instance;
+    }
+
+    public void showModal(Component owner, Modal modal, Option option, String id) {
+        if (isIdExist(id)) {
+            throw new IllegalArgumentException("id '" + id + "' already exist");
+        }
+        SwingUtilities.invokeLater(() -> {
+            getModalHeavyWeightContainer(owner).addModal(owner, modal, option, id);
+        });
+    }
+
+    public void closeAllModal() {
+        map.values().forEach(con -> {
+            con.closeAllModal();
+        });
+    }
+
+    public void closeAllModalImmediately() {
+        map.values().forEach(con -> {
+            con.closeAllModalImmediately();
+        });
+    }
+
+    public boolean isIdExist(String id) {
+        for (Map.Entry<Window, ModalHeavyWeightContainerLayer> entry : getInstance().map.entrySet()) {
+            if (entry.getValue().checkId(id)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public ModalHeavyWeightContainerLayer getModalHeavyWeightContainerById(String id) {
+        for (Map.Entry<Window, ModalHeavyWeightContainerLayer> entry : map.entrySet()) {
+            if (entry.getValue().checkId(id)) {
+                return entry.getValue();
+            }
+        }
+        return null;
+    }
+
+    public ModalHeavyWeightContainerLayer getModalHeavyWeightContainer(Component owner) {
+        Window window = owner instanceof Window ? ((Window) owner) : SwingUtilities.getWindowAncestor(owner);
+        if (map.containsKey(window)) {
+            return map.get(window);
+        } else {
+            ModalHeavyWeightContainerLayer modalHeavyWeightContainerLayer = new ModalHeavyWeightContainerLayer(window);
+            modalHeavyWeightContainerLayer.installWindowListener();
+            map.put(window, modalHeavyWeightContainerLayer);
+            return modalHeavyWeightContainerLayer;
+        }
+    }
+}

--- a/modal-dialog/src/main/java/raven/modal/component/ModalHeavyWeight.java
+++ b/modal-dialog/src/main/java/raven/modal/component/ModalHeavyWeight.java
@@ -70,8 +70,7 @@ public class ModalHeavyWeight {
         if (map.containsKey(window)) {
             return map.get(window);
         } else {
-            ModalHeavyWeightContainerLayer modalHeavyWeightContainerLayer = new ModalHeavyWeightContainerLayer(window);
-            modalHeavyWeightContainerLayer.installWindowListener();
+            ModalHeavyWeightContainerLayer modalHeavyWeightContainerLayer = new ModalHeavyWeightContainerLayer(map, window);
             map.put(window, modalHeavyWeightContainerLayer);
             return modalHeavyWeightContainerLayer;
         }

--- a/modal-dialog/src/main/java/raven/modal/component/ModalHeavyWeightContainerLayer.java
+++ b/modal-dialog/src/main/java/raven/modal/component/ModalHeavyWeightContainerLayer.java
@@ -1,0 +1,115 @@
+package raven.modal.component;
+
+import com.formdev.flatlaf.ui.FlatUIUtils;
+import raven.modal.utils.ModalUtils;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ComponentAdapter;
+import java.awt.event.ComponentEvent;
+import java.awt.event.ComponentListener;
+import java.awt.event.WindowStateListener;
+import java.beans.PropertyChangeListener;
+
+/**
+ * @author Raven
+ */
+public class ModalHeavyWeightContainerLayer extends AbstractModalContainerLayer {
+
+    private final Window parentWindow;
+    private final JRootPane rootPane;
+    private JWindow window;
+    private PropertyChangeListener propertyListener;
+    private ComponentListener componentListener;
+    private WindowStateListener stateListener;
+
+    public ModalHeavyWeightContainerLayer(Window parentWindow) {
+        this.parentWindow = parentWindow;
+        this.rootPane = SwingUtilities.getRootPane(parentWindow);
+        init();
+    }
+
+    private void init() {
+        window = new JWindow(parentWindow);
+        window.setBackground(new Color(0, 0, 0, 0));
+        window.setContentPane(layeredPane);
+    }
+
+    @Override
+    public void showContainer(boolean show) {
+        updateLayout();
+        window.setVisible(true);
+    }
+
+    @Override
+    public void removeContainer(ModalContainer container) {
+        super.removeContainer(container);
+        if (containers.isEmpty()) {
+            window.dispose();
+        }
+    }
+
+    private void updateLayout() {
+        Component contentPane = rootPane.getContentPane();
+        boolean isFullWindowContent = ModalUtils.isFullWindowContent(rootPane);
+        Rectangle parentRec = parentWindow.getBounds();
+        Insets parentInsets = parentWindow.getInsets();
+        parentInsets.top += contentPane.getY();
+        if (isFullWindowContent) {
+            parentInsets.top += 1;
+        }
+        Rectangle rectangle = FlatUIUtils.subtractInsets(parentRec, parentInsets);
+        window.setBounds(rectangle);
+        window.revalidate();
+    }
+
+    private void remove() {
+        closeAllModalImmediately();
+        componentListener = null;
+        propertyListener = null;
+        stateListener = null;
+        window.dispose();
+        window = null;
+    }
+
+    protected void installWindowListener() {
+        propertyListener = evt -> {
+            if (evt.getNewValue() == null && evt.getOldValue() instanceof RootPaneContainer) {
+                uninstallWindowListener((RootPaneContainer) evt.getOldValue());
+            }
+        };
+        componentListener = new ComponentAdapter() {
+            @Override
+            public void componentResized(ComponentEvent e) {
+                updateLayout();
+            }
+
+            @Override
+            public void componentMoved(ComponentEvent e) {
+                updateLayout();
+            }
+        };
+        stateListener = e -> {
+            if (e.getNewState() == 6 || e.getNewState() == 0) {
+                SwingUtilities.invokeLater(() -> {
+                    updateModalLayout();
+                });
+            }
+        };
+
+        if (parentWindow instanceof RootPaneContainer) {
+            ((RootPaneContainer) parentWindow).getRootPane().addPropertyChangeListener("ancestor", propertyListener);
+        }
+        parentWindow.addComponentListener(componentListener);
+        parentWindow.addWindowStateListener(stateListener);
+    }
+
+    protected void uninstallWindowListener(RootPaneContainer rootPaneContainer) {
+        parentWindow.removeComponentListener(componentListener);
+        parentWindow.removeWindowStateListener(stateListener);
+        if (parentWindow instanceof RootPaneContainer) {
+            rootPaneContainer.getRootPane().removePropertyChangeListener("ancestor", propertyListener);
+        }
+        remove();
+    }
+}

--- a/modal-dialog/src/main/java/raven/modal/component/ModalWindow.java
+++ b/modal-dialog/src/main/java/raven/modal/component/ModalWindow.java
@@ -39,7 +39,6 @@ public class ModalWindow extends JWindow {
         layeredPane.setLayout(new FullContentLayout());
         setContentPane(layeredPane);
         setBackground(new Color(0, 0, 0, 0));
-        setAlwaysOnTop(true);
         installParentWindowListener();
     }
 

--- a/modal-dialog/src/main/java/raven/modal/component/ModalWindow.java
+++ b/modal-dialog/src/main/java/raven/modal/component/ModalWindow.java
@@ -1,0 +1,122 @@
+package raven.modal.component;
+
+import com.formdev.flatlaf.ui.FlatUIUtils;
+import raven.modal.layout.FullContentLayout;
+import raven.modal.toast.ToastHeavyWeightContainerLayer;
+import raven.modal.utils.ModalUtils;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ComponentAdapter;
+import java.awt.event.ComponentEvent;
+import java.awt.event.ComponentListener;
+import java.beans.PropertyChangeListener;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Raven
+ */
+public class ModalWindow extends JWindow {
+
+    private final Window parentWindow;
+    private final JRootPane parentRootPane;
+    private JLayeredPane layeredPane;
+    private PropertyChangeListener propertyListener;
+    private ComponentListener componentListener;
+    private List<HeavyWindowAction> list;
+
+    public ModalWindow(Window window) {
+        super(window);
+        this.parentWindow = window;
+        this.parentRootPane = SwingUtilities.getRootPane(window);
+        init();
+    }
+
+    private void init() {
+        layeredPane = new JLayeredPane();
+        list = new ArrayList<>();
+        layeredPane.setLayout(new FullContentLayout());
+        setContentPane(layeredPane);
+        setBackground(new Color(0, 0, 0, 0));
+        setAlwaysOnTop(true);
+        installParentWindowListener();
+    }
+
+    public void addToast(ToastHeavyWeightContainerLayer toast) {
+        list.add(toast);
+        layeredPane.add(toast.getLayeredPane(), JLayeredPane.POPUP_LAYER);
+    }
+
+    public void addModal(ModalHeavyWeightContainerLayer modal) {
+        list.add(modal);
+        layeredPane.add(modal.getLayeredPane(), JLayeredPane.MODAL_LAYER + 1);
+    }
+
+    public void updateLayout() {
+        Component contentPane = parentRootPane.getContentPane();
+        boolean isFullWindowContent = ModalUtils.isFullWindowContent(parentRootPane);
+        Rectangle parentRec = parentWindow.getBounds();
+        Insets parentInsets = parentWindow.getInsets();
+        parentInsets.top += contentPane.getY();
+        if (isFullWindowContent) {
+            parentInsets.top += 1;
+        }
+        Rectangle rectangle = FlatUIUtils.subtractInsets(parentRec, parentInsets);
+        setBounds(rectangle);
+        revalidate();
+    }
+
+    public void setShowWindowAndCheck(boolean show) {
+        if (show) {
+            setVisible(true);
+        } else {
+            for (HeavyWindowAction com : list) {
+                if (!com.isEmptyItem()) {
+                    return;
+                }
+            }
+            setVisible(false);
+        }
+    }
+
+    protected void installParentWindowListener() {
+        propertyListener = evt -> {
+            if (evt.getNewValue() == null && evt.getOldValue() instanceof RootPaneContainer) {
+                uninstallWindowListener((RootPaneContainer) evt.getOldValue());
+            }
+        };
+        componentListener = new ComponentAdapter() {
+            @Override
+            public void componentResized(ComponentEvent e) {
+                updateLayout();
+            }
+
+            @Override
+            public void componentMoved(ComponentEvent e) {
+                updateLayout();
+            }
+        };
+
+        if (parentWindow instanceof RootPaneContainer) {
+            ((RootPaneContainer) parentWindow).getRootPane().addPropertyChangeListener("ancestor", propertyListener);
+        }
+        parentWindow.addComponentListener(componentListener);
+    }
+
+    protected void uninstallWindowListener(RootPaneContainer rootPaneContainer) {
+        parentWindow.removeComponentListener(componentListener);
+        if (parentWindow instanceof RootPaneContainer) {
+            rootPaneContainer.getRootPane().removePropertyChangeListener("ancestor", propertyListener);
+        }
+        remove();
+    }
+
+    private void remove() {
+        list.forEach(com -> com.windowRemoved());
+        componentListener = null;
+        propertyListener = null;
+        dispose();
+        HeavyWeightWindowShared.getInstance().remove(parentWindow);
+    }
+}

--- a/modal-dialog/src/main/java/raven/modal/component/OutlineBorder.java
+++ b/modal-dialog/src/main/java/raven/modal/component/OutlineBorder.java
@@ -71,7 +71,7 @@ public class OutlineBorder extends FlatEmptyBorder {
 
     private static float getBorderWidth(float borderWidth, float round) {
         float innerArc = round - (borderWidth * 2f);
-        return borderWidth + (innerArc * inner);
+        return (float) Math.ceil((borderWidth + Math.max((innerArc * inner), 0)));
     }
 
     @Override

--- a/modal-dialog/src/main/java/raven/modal/component/SimpleModalBorder.java
+++ b/modal-dialog/src/main/java/raven/modal/component/SimpleModalBorder.java
@@ -222,7 +222,7 @@ public class SimpleModalBorder extends Modal implements ModalBorderAction {
         return new ModalController(this) {
             @Override
             public void close() {
-                getController().getModalContainer().closeModal();
+                getController().closeModal();
             }
         };
     }
@@ -238,12 +238,12 @@ public class SimpleModalBorder extends Modal implements ModalBorderAction {
     @Override
     public void doAction(int action) {
         if (callback == null) {
-            getController().getModalContainer().closeModal();
+            getController().closeModal();
         } else {
             ModalController controller = createController();
             callback.action(controller, action);
             if (!controller.getConsume()) {
-                getController().getModalContainer().closeModal();
+                getController().closeModal();
             }
         }
     }

--- a/modal-dialog/src/main/java/raven/modal/drawer/DrawerLayoutResponsive.java
+++ b/modal-dialog/src/main/java/raven/modal/drawer/DrawerLayoutResponsive.java
@@ -112,7 +112,7 @@ public class DrawerLayoutResponsive {
     }
 
     public Rectangle getDrawerLayout(Container parent) {
-        return OptionLayoutUtils.getLayoutLocation(parent, drawerPanel, 1f, drawerPanel.getDrawerOption().getLayoutOption());
+        return OptionLayoutUtils.getLayoutLocation(parent, null, drawerPanel, 1f, drawerPanel.getDrawerOption().getLayoutOption());
     }
 
     public boolean isHorizontalDrawer() {

--- a/modal-dialog/src/main/java/raven/modal/layout/ModalLayout.java
+++ b/modal-dialog/src/main/java/raven/modal/layout/ModalLayout.java
@@ -2,6 +2,7 @@ package raven.modal.layout;
 
 import com.formdev.flatlaf.ui.FlatUIUtils;
 import com.formdev.flatlaf.util.UIScale;
+import raven.modal.component.ModalController;
 import raven.modal.option.LayoutOption;
 
 import java.awt.*;
@@ -15,11 +16,11 @@ public class ModalLayout implements LayoutManager {
         this.animate = animate;
     }
 
-    private Component component;
+    private ModalController component;
     private final LayoutOption layoutOption;
     private float animate;
 
-    public ModalLayout(Component component, LayoutOption layoutOption) {
+    public ModalLayout(ModalController component, LayoutOption layoutOption) {
         this.component = component;
         this.layoutOption = layoutOption;
     }
@@ -50,7 +51,7 @@ public class ModalLayout implements LayoutManager {
     public void layoutContainer(Container parent) {
         synchronized (parent.getTreeLock()) {
             if (component != null && component.isVisible()) {
-                Rectangle rec = OptionLayoutUtils.getLayoutLocation(parent, component, animate, layoutOption);
+                Rectangle rec = OptionLayoutUtils.getLayoutLocation(parent, component.getModalContainer().getOwner(), component, animate, layoutOption);
                 component.setBounds(rec.x, rec.y, rec.width, rec.height);
             }
         }

--- a/modal-dialog/src/main/java/raven/modal/layout/OptionLayoutUtils.java
+++ b/modal-dialog/src/main/java/raven/modal/layout/OptionLayoutUtils.java
@@ -6,6 +6,7 @@ import raven.modal.option.LayoutOption;
 import raven.modal.option.Location;
 import raven.modal.utils.DynamicSize;
 
+import javax.swing.*;
 import java.awt.*;
 
 /**
@@ -13,8 +14,13 @@ import java.awt.*;
  */
 public class OptionLayoutUtils {
 
-    public static Rectangle getLayoutLocation(Container parent, Component component, float animate, LayoutOption layoutOption) {
-        Insets insets = FlatUIUtils.addInsets(parent.getInsets(), UIScale.scale(layoutOption.getMargin()));
+    public static Rectangle getLayoutLocation(Container parent, Component owner, Component component, float animate, LayoutOption layoutOption) {
+        Insets parentInsert = parent.getInsets();
+        Insets insets = layoutOption.getMargin();
+        if (layoutOption.isRelativeToOwner()) {
+            insets = getOwnerInsert(parent, owner, insets);
+        }
+        insets = FlatUIUtils.addInsets(parentInsert, UIScale.scale(insets));
         int x = insets.left;
         int y = insets.top;
         int width = parent.getWidth() - (insets.left + insets.right);
@@ -42,6 +48,23 @@ public class OptionLayoutUtils {
         int cx = x + point.x + animatePoint.x;
         int cy = y + point.y + animatePoint.y;
         return new Rectangle(cx, cy, comSize.width, comSize.height);
+    }
+
+    public static Insets getOwnerInsert(Component parent, Component owner, Insets insets) {
+        if (owner == null || owner instanceof RootPaneContainer) {
+            return insets;
+        }
+        Rectangle ownerRec = SwingUtilities.convertRectangle(owner.getParent(), owner.getBounds(), parent);
+        int x = UIScale.unscale(ownerRec.x);
+        int y = UIScale.unscale(ownerRec.y);
+        int width = UIScale.unscale(parent.getWidth() - (ownerRec.x + ownerRec.width));
+        int height = UIScale.unscale(parent.getHeight() - (ownerRec.y + ownerRec.height));
+
+        int top = insets.top + y;
+        int left = insets.left + x;
+        int bottom = insets.bottom + height;
+        int right = insets.right + width;
+        return new Insets(top, left, bottom, right);
     }
 
     protected static Point location(int width, int height, Dimension componentSize, DynamicSize size) {

--- a/modal-dialog/src/main/java/raven/modal/layout/OptionLayoutUtils.java
+++ b/modal-dialog/src/main/java/raven/modal/layout/OptionLayoutUtils.java
@@ -17,6 +17,7 @@ public class OptionLayoutUtils {
     public static Rectangle getLayoutLocation(Container parent, Component owner, Component component, float animate, LayoutOption layoutOption) {
         Insets parentInsert = parent.getInsets();
         Insets insets = layoutOption.getMargin();
+        Dimension defaultComSize = getComponentSize(parent, insets);
         if (layoutOption.isRelativeToOwner()) {
             insets = getOwnerInsert(parent, owner, insets);
         }
@@ -25,7 +26,7 @@ public class OptionLayoutUtils {
         int y = insets.top;
         int width = parent.getWidth() - (insets.left + insets.right);
         int height = parent.getHeight() - (insets.top + insets.bottom);
-        Dimension comSize = getComponentSize(component, width, height, animate, layoutOption);
+        Dimension comSize = getComponentSize(component, defaultComSize.width, defaultComSize.height, animate, layoutOption);
         boolean rightToLeft = !parent.getComponentOrientation().isLeftToRight();
         Location lh = layoutOption.getHorizontalLocation();
         Number lx = layoutOption.getLocation().getX();
@@ -111,5 +112,12 @@ public class OptionLayoutUtils {
             x *= -1;
         }
         return new Point(x, y);
+    }
+
+    protected static Dimension getComponentSize(Container parent, Insets layoutInsets) {
+        Insets insets = FlatUIUtils.addInsets(parent.getInsets(), UIScale.scale(layoutInsets));
+        int width = parent.getWidth() - (insets.left + insets.right);
+        int height = parent.getHeight() - (insets.top + insets.bottom);
+        return new Dimension(width, height);
     }
 }

--- a/modal-dialog/src/main/java/raven/modal/layout/ToastLayout.java
+++ b/modal-dialog/src/main/java/raven/modal/layout/ToastLayout.java
@@ -8,8 +8,8 @@ import raven.modal.toast.option.ToastLayoutOption;
 import raven.modal.toast.option.ToastOption;
 
 import java.awt.*;
-import java.util.Arrays;
-import java.util.Collections;
+import java.util.List;
+import java.util.*;
 
 /**
  * @author Raven
@@ -41,32 +41,44 @@ public class ToastLayout implements LayoutManager {
     @Override
     public void layoutContainer(Container parent) {
         synchronized (parent.getTreeLock()) {
-            int count = parent.getComponentCount();
+            Map<Component, List<ToastPanel>> map = mapComponent(parent);
             boolean reverseOrder = Toast.isReverseOrder();
-            Component[] components = Arrays.copyOf(parent.getComponents(), count);
-            if (reverseOrder) {
-                Collections.reverse(Arrays.asList(components));
-            }
-            Insets baseMargin = new Insets(0, 0, 0, 0);
-            for (int i = 0; i < count; i++) {
-                Component component = components[i];
-                if (component instanceof ToastPanel) {
-                    ToastPanel toastPanel = (ToastPanel) component;
+            for (Map.Entry<Component, List<ToastPanel>> entry : map.entrySet()) {
+                List<ToastPanel> list = entry.getValue();
+                if (reverseOrder) {
+                    Collections.reverse(list);
+                }
+                Insets baseMargin = new Insets(0, 0, 0, 0);
+                for (int i = 0; i < list.size(); i++) {
+                    ToastPanel toastPanel = list.get(i);
                     ToastOption option = toastPanel.getToastData().getOption();
-                    LayoutOption layoutOption = option.getLayoutOption().createLayoutOption();
-                    Rectangle rec = OptionLayoutUtils.getLayoutLocation(parent, toastPanel, toastPanel.getAnimate(), layoutOption);
+                    LayoutOption layoutOption = option.getLayoutOption().createLayoutOption(parent, toastPanel.getOwner());
+                    Rectangle rec = OptionLayoutUtils.getLayoutLocation(parent, null, toastPanel, toastPanel.getAnimate(), layoutOption);
                     int index = i;
                     int y = rec.y;
                     if (index > 0) {
                         float ly = getLayoutY(parent, rec.getSize(), layoutOption);
-                        y = getY(components, toastPanel, option.getLayoutOption(), index, rec, baseMargin, ly, toastPanel.getAnimate());
+                        y = getY(list, toastPanel, option.getLayoutOption(), index, rec, baseMargin, ly, toastPanel.getAnimate());
                     } else {
                         baseMargin = UIScale.scale(layoutOption.getMargin());
                     }
-                    component.setBounds(rec.x, y, rec.width, rec.height);
+                    toastPanel.setBounds(rec.x, y, rec.width, rec.height);
                 }
             }
         }
+    }
+
+    public Map<Component, List<ToastPanel>> mapComponent(Container parent) {
+        Map<Component, List<ToastPanel>> map = new LinkedHashMap<>();
+        Component[] components = parent.getComponents();
+        for (Component com : components) {
+            if (com instanceof ToastPanel) {
+                ToastPanel toastPanel = (ToastPanel) com;
+                Component key = toastPanel.getToastData().getOption().getLayoutOption().isRelativeToOwner() ? toastPanel.getOwner() : parent;
+                map.computeIfAbsent(key, k -> new ArrayList<>()).add(toastPanel);
+            }
+        }
+        return map;
     }
 
     private float getLayoutY(Container parent, Dimension comSize, LayoutOption layoutOption) {
@@ -76,7 +88,7 @@ public class ToastLayout implements LayoutManager {
         return point.y;
     }
 
-    private int getY(Component[] components, ToastPanel parentPanel, ToastLayoutOption layoutOption, int index, Rectangle rec, Insets baseMargin, float ly, float animate) {
+    private int getY(List<ToastPanel> components, ToastPanel parentPanel, ToastLayoutOption layoutOption, int index, Rectangle rec, Insets baseMargin, float ly, float animate) {
         ToastPanel previousToast = getToastPanel(components, parentPanel, index - 1);
         if (previousToast == null) {
             return rec.y;
@@ -101,19 +113,15 @@ public class ToastLayout implements LayoutManager {
         return (int) y;
     }
 
-    private ToastPanel getToastPanel(Component[] components, ToastPanel parentPanel, int index) {
+    private ToastPanel getToastPanel(List<ToastPanel> components, ToastPanel parentPanel, int index) {
         if (index <= -1) {
             return null;
         }
-        Component component = components[index];
-        if (component instanceof ToastPanel) {
-            ToastPanel toastPanel = (ToastPanel) component;
-            if (toastPanel.checkSameLayout(parentPanel.getToastData().getOption().getLayoutOption())) {
-                return toastPanel;
-            } else {
-                return getToastPanel(components, parentPanel, index - 1);
-            }
+        ToastPanel component = components.get(index);
+        if (component.checkSameLayout(parentPanel.getToastData().getOption().getLayoutOption())) {
+            return component;
+        } else {
+            return getToastPanel(components, parentPanel, index - 1);
         }
-        return null;
     }
 }

--- a/modal-dialog/src/main/java/raven/modal/option/LayoutOption.java
+++ b/modal-dialog/src/main/java/raven/modal/option/LayoutOption.java
@@ -35,6 +35,10 @@ public class LayoutOption {
         return animateDistance;
     }
 
+    public boolean isRelativeToOwner() {
+        return relativeToOwner;
+    }
+
     public float getAnimateScale() {
         return animateScale;
     }
@@ -43,11 +47,12 @@ public class LayoutOption {
         return onTop;
     }
 
-    private LayoutOption(DynamicSize location, Insets margin, DynamicSize size, DynamicSize animateDistance, float animateScale, boolean onTop) {
+    private LayoutOption(DynamicSize location, Insets margin, DynamicSize size, DynamicSize animateDistance, boolean relativeToOwner, float animateScale, boolean onTop) {
         this.location = location;
         this.margin = margin;
         this.size = size;
         this.animateDistance = animateDistance;
+        this.relativeToOwner = relativeToOwner;
         this.animateScale = animateScale;
         this.onTop = onTop;
     }
@@ -61,6 +66,7 @@ public class LayoutOption {
     private Insets margin = new Insets(7, 7, 7, 7);
     private DynamicSize size = new DynamicSize(-1, -1);
     private DynamicSize animateDistance = new DynamicSize(0, 20);
+    private boolean relativeToOwner;
     private float animateScale;
     private boolean onTop = false;
 
@@ -102,6 +108,11 @@ public class LayoutOption {
         return this;
     }
 
+    public LayoutOption setRelativeToOwner(boolean relativeToOwner) {
+        this.relativeToOwner = relativeToOwner;
+        return this;
+    }
+
     public LayoutOption setOnTop(boolean onTop) {
         this.onTop = onTop;
         return this;
@@ -116,6 +127,6 @@ public class LayoutOption {
     }
 
     public LayoutOption copy() {
-        return new LayoutOption(location, new Insets(margin.top, margin.left, margin.bottom, margin.right), new DynamicSize(size), new DynamicSize(animateDistance), animateScale, onTop);
+        return new LayoutOption(location, new Insets(margin.top, margin.left, margin.bottom, margin.right), new DynamicSize(size), new DynamicSize(animateDistance), relativeToOwner, animateScale, onTop);
     }
 }

--- a/modal-dialog/src/main/java/raven/modal/option/Option.java
+++ b/modal-dialog/src/main/java/raven/modal/option/Option.java
@@ -37,6 +37,10 @@ public class Option {
         return closeOnPressedEscape;
     }
 
+    public boolean isHeavyWeight() {
+        return heavyWeight;
+    }
+
     public Color getBackgroundLight() {
         return backgroundLight;
     }
@@ -63,19 +67,21 @@ public class Option {
     private boolean animationEnabled = true;
     private boolean animationOnClose = true;
     private boolean closeOnPressedEscape = true;
+    private boolean heavyWeight;
     private Color backgroundLight;
     private Color backgroundDark;
     private float opacity = 0.5f;
     private int duration = 200;
     private int sliderDuration = 400;
 
-    private Option(LayoutOption layoutOption, BorderOption borderOption, BackgroundClickType backgroundClickType, boolean animationEnabled, boolean animationOnClose, boolean closeOnPressedEscape, Color backgroundLight, Color backgroundDark, float opacity, int duration, int sliderDuration) {
+    private Option(LayoutOption layoutOption, BorderOption borderOption, BackgroundClickType backgroundClickType, boolean animationEnabled, boolean animationOnClose, boolean closeOnPressedEscape, boolean heavyWeight, Color backgroundLight, Color backgroundDark, float opacity, int duration, int sliderDuration) {
         this.layoutOption = layoutOption;
         this.borderOption = borderOption;
         this.backgroundClickType = backgroundClickType;
         this.animationEnabled = animationEnabled;
         this.animationOnClose = animationOnClose;
         this.closeOnPressedEscape = closeOnPressedEscape;
+        this.heavyWeight = heavyWeight;
         this.backgroundLight = backgroundLight;
         this.backgroundDark = backgroundDark;
         this.opacity = opacity;
@@ -111,6 +117,11 @@ public class Option {
         return this;
     }
 
+    public Option setHeavyWeight(boolean heavyWeight) {
+        this.heavyWeight = heavyWeight;
+        return this;
+    }
+
     public Option setBackground(Color color) {
         this.backgroundLight = color;
         this.backgroundDark = color;
@@ -143,6 +154,6 @@ public class Option {
     }
 
     public Option copy() {
-        return new Option(layoutOption.copy(), borderOption.copy(), backgroundClickType, animationEnabled, animationOnClose, closeOnPressedEscape, backgroundLight == null ? null : new Color(backgroundLight.getRGB()), backgroundDark == null ? null : new Color(backgroundDark.getRGB()), opacity, duration, sliderDuration);
+        return new Option(layoutOption.copy(), borderOption.copy(), backgroundClickType, animationEnabled, animationOnClose, closeOnPressedEscape, heavyWeight, backgroundLight == null ? null : new Color(backgroundLight.getRGB()), backgroundDark == null ? null : new Color(backgroundDark.getRGB()), opacity, duration, sliderDuration);
     }
 }

--- a/modal-dialog/src/main/java/raven/modal/toast/AbstractToastContainerLayer.java
+++ b/modal-dialog/src/main/java/raven/modal/toast/AbstractToastContainerLayer.java
@@ -1,0 +1,105 @@
+package raven.modal.toast;
+
+import raven.modal.layout.ToastLayout;
+import raven.modal.toast.option.ToastLocation;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Raven
+ */
+public abstract class AbstractToastContainerLayer {
+
+    protected final List<ToastPanel> toastPanels;
+    protected final JLayeredPane layeredPane;
+
+    public abstract void showContainer(boolean show);
+
+    public AbstractToastContainerLayer() {
+        toastPanels = new ArrayList<>();
+        layeredPane = new JLayeredPane();
+        layeredPane.setLayout(new ToastLayout());
+    }
+
+    public void add(Component component) {
+        layeredPane.add(component, 0);
+    }
+
+    public void remove(Component component) {
+        layeredPane.remove(component);
+        layeredPane.repaint();
+        layeredPane.revalidate();
+    }
+
+    public void addToastPanel(ToastPanel toastPanel) {
+        toastPanels.add(toastPanel);
+        toastPanel.revalidate();
+        toastPanel.repaint();
+        showContainer(true);
+    }
+
+    public void removeToastPanel(ToastPanel toastPanel) {
+        if (toastPanels != null) {
+            toastPanels.remove(toastPanel);
+            if (toastPanels.isEmpty()) {
+                showContainer(false);
+            }
+        }
+    }
+
+    public void closeAll() {
+        synchronized (toastPanels) {
+            for (int i = toastPanels.size() - 1; i >= 0; i--) {
+                ToastPanel p = toastPanels.get(i);
+                if (!p.isCurrenPromise()) {
+                    toastPanels.get(i).stop();
+                }
+            }
+        }
+    }
+
+    public boolean checkPromiseId(String id) {
+        synchronized (toastPanels) {
+            for (int i = toastPanels.size() - 1; i >= 0; i--) {
+                ToastPanel p = toastPanels.get(i);
+                if (p.checkPromiseId(id)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+    public void closeAll(ToastLocation location) {
+        synchronized (toastPanels) {
+            for (int i = toastPanels.size() - 1; i >= 0; i--) {
+                ToastPanel p = toastPanels.get(i);
+                if (p.checkSameLayout(location)) {
+                    if (!p.isCurrenPromise()) {
+                        p.stop();
+                    }
+                }
+            }
+        }
+    }
+
+    public void closeAllImmediately() {
+        synchronized (toastPanels) {
+            for (int i = toastPanels.size() - 1; i >= 0; i--) {
+                ToastPanel p = toastPanels.get(i);
+                p.close();
+            }
+        }
+    }
+
+    public List<ToastPanel> getToastPanels() {
+        return toastPanels;
+    }
+
+    public JLayeredPane getLayeredPane() {
+        return layeredPane;
+    }
+}

--- a/modal-dialog/src/main/java/raven/modal/toast/ToastContainerLayer.java
+++ b/modal-dialog/src/main/java/raven/modal/toast/ToastContainerLayer.java
@@ -4,6 +4,7 @@ import raven.modal.layout.ToastLayout;
 import raven.modal.toast.option.ToastLocation;
 
 import javax.swing.*;
+import java.awt.event.WindowStateListener;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -14,6 +15,7 @@ public class ToastContainerLayer extends JLayeredPane {
 
     private List<ToastPanel> toastPanels;
     private Object propertyData;
+    private WindowStateListener windowListener;
 
     public ToastContainerLayer() {
         init();
@@ -91,9 +93,18 @@ public class ToastContainerLayer extends JLayeredPane {
         this.propertyData = propertyData;
     }
 
+    public WindowStateListener getWindowListener() {
+        return windowListener;
+    }
+
+    public void setWindowListener(WindowStateListener windowListener) {
+        this.windowListener = windowListener;
+    }
+
     public void remove() {
         closeAllAsRemove();
         toastPanels = null;
         propertyData = null;
+        windowListener = null;
     }
 }

--- a/modal-dialog/src/main/java/raven/modal/toast/ToastHeavyWeight.java
+++ b/modal-dialog/src/main/java/raven/modal/toast/ToastHeavyWeight.java
@@ -1,0 +1,72 @@
+package raven.modal.toast;
+
+import raven.modal.toast.option.ToastLocation;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Raven
+ */
+public class ToastHeavyWeight {
+
+    private static ToastHeavyWeight instance;
+    private Map<Window, ToastHeavyWeightContainerLayer> map;
+
+    private ToastHeavyWeight() {
+        map = new HashMap<>();
+    }
+
+    public static ToastHeavyWeight getInstance() {
+        if (instance == null) {
+            instance = new ToastHeavyWeight();
+        }
+        return instance;
+    }
+
+    public void updateLayout() {
+        for (ToastHeavyWeightContainerLayer com : map.values()) {
+            com.getLayeredPane().revalidate();
+        }
+    }
+
+    public boolean checkPromiseId(String id) {
+        for (ToastHeavyWeightContainerLayer com : map.values()) {
+            if (com.checkPromiseId(id)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public void closeAll() {
+        map.values().forEach(con -> {
+            con.closeAll();
+        });
+    }
+
+    public void closeAll(ToastLocation location) {
+        map.values().forEach(con -> {
+            con.closeAll(location);
+        });
+    }
+
+    public void closeAllImmediately() {
+        map.values().forEach(con -> {
+            con.closeAllImmediately();
+        });
+    }
+
+    public AbstractToastContainerLayer getToastHeavyWeightContainer(Component owner) {
+        Window window = owner instanceof Window ? ((Window) owner) : SwingUtilities.getWindowAncestor(owner);
+        if (map.containsKey(window)) {
+            return map.get(window);
+        } else {
+            ToastHeavyWeightContainerLayer toastHeavyWeightContainerLayer = new ToastHeavyWeightContainerLayer(map, window);
+            map.put(window, toastHeavyWeightContainerLayer);
+            return toastHeavyWeightContainerLayer;
+        }
+    }
+}

--- a/modal-dialog/src/main/java/raven/modal/toast/ToastHeavyWeightContainerLayer.java
+++ b/modal-dialog/src/main/java/raven/modal/toast/ToastHeavyWeightContainerLayer.java
@@ -1,4 +1,8 @@
-package raven.modal.component;
+package raven.modal.toast;
+
+import raven.modal.component.HeavyWeightWindowShared;
+import raven.modal.component.HeavyWindowAction;
+import raven.modal.component.ModalWindow;
 
 import java.awt.*;
 import java.util.Map;
@@ -6,13 +10,12 @@ import java.util.Map;
 /**
  * @author Raven
  */
-public class ModalHeavyWeightContainerLayer extends AbstractModalContainerLayer implements HeavyWindowAction {
-
-    private final Map<Window, ModalHeavyWeightContainerLayer> map;
+public class ToastHeavyWeightContainerLayer extends AbstractToastContainerLayer implements HeavyWindowAction {
+    private final Map<Window, ToastHeavyWeightContainerLayer> map;
     private final Window parentWindow;
     private ModalWindow window;
 
-    public ModalHeavyWeightContainerLayer(Map<Window, ModalHeavyWeightContainerLayer> map, Window parentWindow) {
+    public ToastHeavyWeightContainerLayer(Map<Window, ToastHeavyWeightContainerLayer> map, Window parentWindow) {
         this.map = map;
         this.parentWindow = parentWindow;
         init();
@@ -20,32 +23,25 @@ public class ModalHeavyWeightContainerLayer extends AbstractModalContainerLayer 
 
     private void init() {
         window = HeavyWeightWindowShared.getInstance().getWindowShared(parentWindow);
-        window.addModal(this);
+        window.addToast(this);
         window.updateLayout();
     }
 
     @Override
     public void showContainer(boolean show) {
+        layeredPane.setVisible(show);
         window.updateLayout();
         window.setShowWindowAndCheck(show);
     }
 
     @Override
-    public void removeContainer(ModalContainer container) {
-        super.removeContainer(container);
-        if (containers.isEmpty()) {
-            window.setShowWindowAndCheck(false);
-        }
-    }
-
-    @Override
     public void windowRemoved() {
-        closeAllModalImmediately();
+        closeAllImmediately();
         map.remove(parentWindow);
     }
 
     @Override
     public boolean isEmptyItem() {
-        return containers.isEmpty();
+        return toastPanels.isEmpty();
     }
 }

--- a/modal-dialog/src/main/java/raven/modal/toast/ToastPanel.java
+++ b/modal-dialog/src/main/java/raven/modal/toast/ToastPanel.java
@@ -27,7 +27,12 @@ public class ToastPanel extends JPanel {
         return animate;
     }
 
+    public Component getOwner() {
+        return owner;
+    }
+
     private final ToastContainerLayer toastContainerLayer;
+    private final Component owner;
     private ToastData toastData;
     private ToastContent content;
     private JTextArea textMessage;
@@ -45,8 +50,9 @@ public class ToastPanel extends JPanel {
     private ToastPromise.PromiseCallback promiseCallback;
     private boolean available = true;
 
-    public ToastPanel(ToastContainerLayer toastContainerLayer, ToastData toastData) {
+    public ToastPanel(ToastContainerLayer toastContainerLayer, Component owner, ToastData toastData) {
         this.toastContainerLayer = toastContainerLayer;
+        this.owner = owner;
         this.toastData = toastData;
         init();
     }

--- a/modal-dialog/src/main/java/raven/modal/toast/ToastPanel.java
+++ b/modal-dialog/src/main/java/raven/modal/toast/ToastPanel.java
@@ -31,7 +31,7 @@ public class ToastPanel extends JPanel {
         return owner;
     }
 
-    private final ToastContainerLayer toastContainerLayer;
+    private final AbstractToastContainerLayer toastContainerLayer;
     private final Component owner;
     private ToastData toastData;
     private ToastContent content;
@@ -50,7 +50,7 @@ public class ToastPanel extends JPanel {
     private ToastPromise.PromiseCallback promiseCallback;
     private boolean available = true;
 
-    public ToastPanel(ToastContainerLayer toastContainerLayer, Component owner, ToastData toastData) {
+    public ToastPanel(AbstractToastContainerLayer toastContainerLayer, Component owner, ToastData toastData) {
         this.toastContainerLayer = toastContainerLayer;
         this.owner = owner;
         this.toastData = toastData;
@@ -60,6 +60,9 @@ public class ToastPanel extends JPanel {
     private void init() {
         setLayout(new BorderLayout());
         setOpaque(false);
+        if (toastData.getOption().isAnimationEnabled()) {
+            animate = 0f;
+        }
         putClientProperty(FlatClientProperties.STYLE, "" +
                 "background:$TextArea.background;");
     }
@@ -341,7 +344,7 @@ public class ToastPanel extends JPanel {
                     @Override
                     public void timingEvent(float v) {
                         animate = showing ? v : 1f - v;
-                        toastContainerLayer.revalidate();
+                        toastContainerLayer.getLayeredPane().revalidate();
                     }
 
                     @Override
@@ -446,8 +449,6 @@ public class ToastPanel extends JPanel {
         }
         toastData = null;
         toastContainerLayer.remove(this);
-        toastContainerLayer.repaint();
-        toastContainerLayer.revalidate();
         content = null;
         textMessage = null;
         labelIcon = null;

--- a/modal-dialog/src/main/java/raven/modal/toast/option/ToastLayoutOption.java
+++ b/modal-dialog/src/main/java/raven/modal/toast/option/ToastLayoutOption.java
@@ -1,5 +1,6 @@
 package raven.modal.toast.option;
 
+import raven.modal.layout.OptionLayoutUtils;
 import raven.modal.option.LayoutOption;
 import raven.modal.utils.DynamicSize;
 
@@ -22,6 +23,10 @@ public class ToastLayoutOption {
         return locationSize;
     }
 
+    public boolean isRelativeToOwner() {
+        return relativeToOwner;
+    }
+
     public ToastDirection getDirection() {
         if (direction != null) {
             return direction;
@@ -29,10 +34,11 @@ public class ToastLayoutOption {
         return location.getDirection();
     }
 
-    private ToastLayoutOption(ToastLocation location, DynamicSize locationSize, ToastDirection direction) {
+    private ToastLayoutOption(ToastLocation location, DynamicSize locationSize, ToastDirection direction, boolean relativeToOwner) {
         this.location = location;
         this.locationSize = locationSize;
         this.direction = direction;
+        this.relativeToOwner = relativeToOwner;
     }
 
     public ToastLayoutOption() {
@@ -41,6 +47,7 @@ public class ToastLayoutOption {
     private ToastLocation location = ToastLocation.TOP_CENTER;
     private DynamicSize locationSize;
     private ToastDirection direction;
+    private boolean relativeToOwner;
     private Insets margin = new Insets(7, 7, 7, 7);
 
     public ToastLayoutOption setLocation(ToastLocation location) {
@@ -59,6 +66,11 @@ public class ToastLayoutOption {
         return this;
     }
 
+    public ToastLayoutOption setRelativeToOwner(boolean relativeToOwner) {
+        this.relativeToOwner = relativeToOwner;
+        return this;
+    }
+
     public ToastLayoutOption setMargin(int top, int left, int bottom, int right) {
         this.margin = new Insets(top, left, bottom, right);
         return this;
@@ -69,10 +81,15 @@ public class ToastLayoutOption {
         return this;
     }
 
-    public LayoutOption createLayoutOption() {
+    public LayoutOption createLayoutOption(Component parent, Component owner) {
         ToastDirection direction = getDirection();
+        Insets insets = new Insets(margin.top, margin.left, margin.bottom, margin.right);
+        if (isRelativeToOwner()) {
+            insets = OptionLayoutUtils.getOwnerInsert(parent, owner, insets);
+        }
         LayoutOption layoutOption = new LayoutOption()
-                .setMargin(margin.top, margin.left, margin.bottom, margin.right)
+                .setRelativeToOwner(isRelativeToOwner())
+                .setMargin(insets.top, insets.left, insets.bottom, insets.right)
                 .setAnimateDistance(direction.getValue().getX(), direction.getValue().getY());
 
         if (locationSize != null) {
@@ -85,6 +102,6 @@ public class ToastLayoutOption {
     }
 
     public ToastLayoutOption copy() {
-        return new ToastLayoutOption(location, locationSize, direction);
+        return new ToastLayoutOption(location, locationSize, direction, relativeToOwner);
     }
 }

--- a/modal-dialog/src/main/java/raven/modal/toast/option/ToastOption.java
+++ b/modal-dialog/src/main/java/raven/modal/toast/option/ToastOption.java
@@ -23,6 +23,10 @@ public class ToastOption {
         return animationEnabled;
     }
 
+    public boolean isHeavyWeight() {
+        return heavyWeight;
+    }
+
     public boolean isPauseDelayOnHover() {
         return pauseDelayOnHover;
     }
@@ -43,10 +47,11 @@ public class ToastOption {
         return delay;
     }
 
-    public ToastOption(ToastLayoutOption layoutOption, ToastStyle style, boolean animationEnabled, boolean pauseDelayOnHover, boolean autoClose, boolean closeOnClick, int duration, int delay) {
+    public ToastOption(ToastLayoutOption layoutOption, ToastStyle style, boolean animationEnabled, boolean heavyWeight, boolean pauseDelayOnHover, boolean autoClose, boolean closeOnClick, int duration, int delay) {
         this.layoutOption = layoutOption;
         this.style = style;
         this.animationEnabled = animationEnabled;
+        this.heavyWeight = heavyWeight;
         this.pauseDelayOnHover = pauseDelayOnHover;
         this.autoClose = autoClose;
         this.closeOnClick = closeOnClick;
@@ -60,6 +65,7 @@ public class ToastOption {
     private ToastLayoutOption layoutOption = ToastLayoutOption.getDefault();
     private ToastStyle style = ToastStyle.getDefault();
     private boolean animationEnabled = true;
+    private boolean heavyWeight;
     private boolean pauseDelayOnHover = true;
     private boolean autoClose = true;
     private boolean closeOnClick;
@@ -78,6 +84,11 @@ public class ToastOption {
 
     public ToastOption setAnimationEnabled(boolean animationEnabled) {
         this.animationEnabled = animationEnabled;
+        return this;
+    }
+
+    public ToastOption setHeavyWeight(boolean heavyWeight) {
+        this.heavyWeight = heavyWeight;
         return this;
     }
 
@@ -107,6 +118,6 @@ public class ToastOption {
     }
 
     public ToastOption copy() {
-        return new ToastOption(layoutOption.copy(), style.copy(), animationEnabled, pauseDelayOnHover, autoClose, closeOnClick, duration, delay);
+        return new ToastOption(layoutOption.copy(), style.copy(), animationEnabled, heavyWeight, pauseDelayOnHover, autoClose, closeOnClick, duration, delay);
     }
 }

--- a/modal-dialog/src/main/java/raven/modal/utils/ModalUtils.java
+++ b/modal-dialog/src/main/java/raven/modal/utils/ModalUtils.java
@@ -1,8 +1,8 @@
 package raven.modal.utils;
 
-import com.formdev.flatlaf.ui.FlatUIUtils;
-
+import javax.swing.*;
 import java.awt.*;
+import java.awt.event.WindowStateListener;
 
 /**
  * @author Raven
@@ -19,5 +19,20 @@ public class ModalUtils {
         int maxTopBottom = Math.min(insets.top, insets.bottom);
         int maxLeftRight = Math.min(insets.left, insets.right);
         return Math.min(maxTopBottom, maxLeftRight);
+    }
+
+    public static WindowStateListener installWindowStateListener(RootPaneContainer rootPane, WindowStateListener listener) {
+        Window window = SwingUtilities.getWindowAncestor(rootPane.getRootPane());
+        if (window != null) {
+            window.addWindowStateListener(listener);
+        }
+        return listener;
+    }
+
+    public static void uninstallWindowStateListener(RootPaneContainer rootPane, WindowStateListener listener) {
+        Window window = SwingUtilities.getWindowAncestor(rootPane.getRootPane());
+        if (window != null) {
+            window.removeWindowStateListener(listener);
+        }
     }
 }

--- a/modal-dialog/src/main/java/raven/modal/utils/ModalUtils.java
+++ b/modal-dialog/src/main/java/raven/modal/utils/ModalUtils.java
@@ -1,5 +1,7 @@
 package raven.modal.utils;
 
+import com.formdev.flatlaf.FlatClientProperties;
+
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.WindowStateListener;
@@ -34,5 +36,9 @@ public class ModalUtils {
         if (window != null) {
             window.removeWindowStateListener(listener);
         }
+    }
+
+    public static boolean isFullWindowContent(JRootPane rootPane) {
+        return FlatClientProperties.clientPropertyBoolean(rootPane, FlatClientProperties.FULL_WINDOW_CONTENT, false);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.dj-raven</groupId>
     <artifactId>swing-modal-dialog</artifactId>
-    <version>2.2.0</version>
+    <version>2.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <modules>
         <module>modal-dialog</module>


### PR DESCRIPTION
This PR  add new option for modal dialog and toast

- `heavyWeight` by default `false` if set to true, the modal and toast will show by create `JWindow`
- `relativeToOwner` by default `false` if set to true, the location modal and toast will show
      relative to the owner component

### Example

- Modal dialog
``` java
// apply to default
ModalDialog.getDefaultOption()
        .setHeavyWeight(true);

// apply individual option
Option option = ModalDialog.createOption();
option.setHeavyWeight(true);
```

``` java
// apply to default
ModalDialog.getDefaultOption()
        .getLayoutOption().setRelativeToOwner(true);

// apply individual option
Option option = ModalDialog.createOption();
option.getLayoutOption().setRelativeToOwner(true);
```
- Toast

``` java
// apply to default
Toast.getDefaultOption()
        .setHeavyWeight(true);

// apply individual option
ToastOption option = Toast.createOption();
option.setHeavyWeight(true);
```

``` java
// apply to default
Toast.getDefaultOption()
        .getLayoutOption().setRelativeToOwner(true);

// apply individual option
ToastOption option = Toast.createOption();
option.getLayoutOption().setRelativeToOwner(true);
```

- Apply both option to default

``` java
ModalDialog.getDefaultOption()
        .setHeavyWeight(true)
            .getLayoutOption()
            .setRelativeToOwner(true);
```
