### PR TITLE
Modal and Toast: add `relativeToOwnerType` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
         - `RELATIVE_GLOBAL`: background spans the entire window.
         - `RELATIVE_BOUNDLESS`: background covers the owner, but the modal can extend outside the owner. Tracks owner's
           visibility. (requires `heavyWeight` = `true`)
+    - Add new option `backgroundPadding` to padding the background. by default `insets(0,0,0,0)`
 
 ### Fixed bugs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,18 @@
     - Add new layout option `relativeToOwner` by default `false` if set to true, the location modal and toast will show
       relative to the owner component
 - Modal dialog
-    - Add new option `relativeToOwnerType`  (requires `relativeToOwner` = `true`) with 3 types:
+    - Add new option `relativeToOwnerType` (requires `relativeToOwner` = `true`) with 3 types:
         - `RELATIVE_CONTAINED`: modal and background are confined to the owner's bounds and track the owner's
           visibility (`default`)
-        - `RELATIVE_GLOBAL`: background spans the entire window.
+        - `RELATIVE_GLOBAL`: background spans the entire window and does not track the owner's visibility
         - `RELATIVE_BOUNDLESS`: background covers the owner, but the modal can extend outside the owner. Tracks owner's
           visibility. (requires `heavyWeight` = `true`)
     - Add new option `backgroundPadding` to padding the background. by default `insets(0,0,0,0)`
+- Toast
+    - Add new option `relativeToOwnerType` (requires `relativeToOwner` = `true`) with 3 types:
+        - `RELATIVE_CONTAINED`: toast is confined to the owner's bounds and tracks the owner's visibility. (`default`)
+        - `RELATIVE_GLOBAL`: toast spans the entire window and does not track the owner's visibility
+        - `RELATIVE_BOUNDLESS`: toast can extend outside the owner's bounds and tracks the owner's visibility
 
 ### Fixed bugs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@
     - Add new option `heavyWeight` by default `false` if set to true, the modal and toast will show by create `JWindow`
     - Add new layout option `relativeToOwner` by default `false` if set to true, the location modal and toast will show
       relative to the owner component
+- Modal dialog
+    - Add new option `relativeToOwnerType`  (requires `relativeToOwner` = `true`) with 3 types:
+        - `RELATIVE_CONTAINED`: modal and background are confined to the owner's bounds and track the owner's
+          visibility (`default`)
+        - `RELATIVE_GLOBAL`: background spans the entire window.
+        - `RELATIVE_BOUNDLESS`: background covers the owner, but the modal can extend outside the owner. Tracks owner's
+          visibility. (requires `heavyWeight` = `true`)
 
 ### Fixed bugs
 

--- a/modal-dialog/src/main/java/raven/modal/ModalDialog.java
+++ b/modal-dialog/src/main/java/raven/modal/ModalDialog.java
@@ -52,7 +52,8 @@ public class ModalDialog {
         }
         SwingUtilities.invokeLater(() -> {
             boolean isHeavyWeight = option.isHeavyWeight();
-            getInstance().getModalContainer(owner, isHeavyWeight).addModal(owner, modal, option, id);
+            Component modelOwner = option.getLayoutOption().isRelativeToOwner() ? owner : null;
+            getInstance().getModalContainer(owner, isHeavyWeight).addModal(modelOwner, modal, option, id);
         });
     }
 

--- a/modal-dialog/src/main/java/raven/modal/ModalDialog.java
+++ b/modal-dialog/src/main/java/raven/modal/ModalDialog.java
@@ -163,6 +163,9 @@ public class ModalDialog {
             // add modal container layered to window layeredPane
             windowLayeredPane.add(modalContainerLayer.getLayeredPane(), LAYER);
 
+            // init component orientation
+            modalContainerLayer.initComponentOrientation(rootPaneContainer.getRootPane().getComponentOrientation());
+
             // create snapshot layered
             Component snapshot = modalContainerLayer.createLayeredSnapshot();
 

--- a/modal-dialog/src/main/java/raven/modal/Toast.java
+++ b/modal-dialog/src/main/java/raven/modal/Toast.java
@@ -97,7 +97,8 @@ public class Toast {
         RootPaneContainer rootPaneContainer = ModalDialog.getRootPaneContainer(owner);
         AbstractToastContainerLayer toastContainerLayer = getInstance().getToastContainer(owner, option.isHeavyWeight());
         String message = object instanceof String ? object.toString() : null;
-        ToastPanel toastPanel = new ToastPanel(toastContainerLayer, owner, new ToastPanel.ToastData(type, option, themesData, message));
+        Component toastOwner = option.getLayoutOption().isRelativeToOwner() ? owner : null;
+        ToastPanel toastPanel = new ToastPanel(toastContainerLayer, toastOwner, new ToastPanel.ToastData(type, option, themesData, message));
         if (object instanceof Component) {
             toastContainerLayer.add(toastPanel.createToastCustom((Component) object));
         } else if (promise != null) {
@@ -170,7 +171,7 @@ public class Toast {
 
     private void updateLayout() {
         for (ToastContainerLayer com : map.values()) {
-            com.getLayeredPane().revalidate();
+            com.revalidateAll();
         }
         ToastHeavyWeight.getInstance().updateLayout();
     }

--- a/modal-dialog/src/main/java/raven/modal/Toast.java
+++ b/modal-dialog/src/main/java/raven/modal/Toast.java
@@ -193,10 +193,8 @@ public class Toast {
             // add toast container layered to window layeredPane
             windowLayeredPane.add(toastContainerLayer.getLayeredPane(), LAYER);
 
-            // check layout right to left
-            if (rootPaneContainer.getRootPane().getComponentOrientation().isLeftToRight() != toastContainerLayer.getLayeredPane().getComponentOrientation().isLeftToRight()) {
-                toastContainerLayer.getLayeredPane().applyComponentOrientation(rootPaneContainer.getRootPane().getComponentOrientation());
-            }
+            // init component orientation
+            toastContainerLayer.initComponentOrientation(rootPaneContainer.getRootPane().getComponentOrientation());
 
             // set custom layout to window layeredPane
             LayoutManager layout = windowLayeredPane.getLayout();

--- a/modal-dialog/src/main/java/raven/modal/Toast.java
+++ b/modal-dialog/src/main/java/raven/modal/Toast.java
@@ -171,7 +171,7 @@ public class Toast {
 
     private void updateLayout() {
         for (ToastContainerLayer com : map.values()) {
-            com.revalidateAll();
+            com.updateLayout();
         }
         ToastHeavyWeight.getInstance().updateLayout();
     }

--- a/modal-dialog/src/main/java/raven/modal/component/AbstractModalContainerLayer.java
+++ b/modal-dialog/src/main/java/raven/modal/component/AbstractModalContainerLayer.java
@@ -1,6 +1,6 @@
 package raven.modal.component;
 
-import raven.modal.layout.FullContentLayout;
+import raven.modal.layout.ModalContainerLayout;
 import raven.modal.option.Option;
 
 import javax.swing.*;
@@ -19,7 +19,7 @@ public abstract class AbstractModalContainerLayer {
     public AbstractModalContainerLayer() {
         containers = new HashSet<>();
         layeredPane = new JLayeredPane();
-        layeredPane.setLayout(new FullContentLayout());
+        layeredPane.setLayout(new ModalContainerLayout());
     }
 
     protected void animatedBegin() {
@@ -81,9 +81,7 @@ public abstract class AbstractModalContainerLayer {
     }
 
     public void updateModalLayout() {
-        for (ModalContainer con : containers) {
-            con.revalidate();
-        }
+        layeredPane.revalidate();
     }
 
     public boolean checkId(String id) {

--- a/modal-dialog/src/main/java/raven/modal/component/AbstractModalContainerLayer.java
+++ b/modal-dialog/src/main/java/raven/modal/component/AbstractModalContainerLayer.java
@@ -47,6 +47,7 @@ public abstract class AbstractModalContainerLayer {
         layeredPane.setLayer(modalContainer, JLayeredPane.MODAL_LAYER + (option.getLayoutOption().isOnTop() ? 1 : 0));
         layeredPane.add(modalContainer, 0);
         modalContainer.initModal(modal);
+        modalContainer.setComponentOrientation(layeredPane.getComponentOrientation());
         modal.setId(id);
         containers.add(modalContainer);
         return modalContainer;
@@ -111,5 +112,9 @@ public abstract class AbstractModalContainerLayer {
 
     public JLayeredPane getLayeredPane() {
         return layeredPane;
+    }
+
+    public void initComponentOrientation(ComponentOrientation orientation) {
+        layeredPane.setComponentOrientation(orientation);
     }
 }

--- a/modal-dialog/src/main/java/raven/modal/component/AbstractModalContainerLayer.java
+++ b/modal-dialog/src/main/java/raven/modal/component/AbstractModalContainerLayer.java
@@ -1,6 +1,7 @@
 package raven.modal.component;
 
 import raven.modal.layout.ModalContainerLayout;
+import raven.modal.option.LayoutOption;
 import raven.modal.option.Option;
 
 import javax.swing.*;
@@ -11,15 +12,14 @@ import java.util.Set;
 /**
  * @author Raven
  */
-public abstract class AbstractModalContainerLayer {
+public abstract class AbstractModalContainerLayer extends AbstractRelativeContainer implements RelativeLayerPane.LayoutCallback {
 
     protected final Set<ModalContainer> containers;
-    protected final JLayeredPane layeredPane;
 
     public AbstractModalContainerLayer() {
+        super(new ModalContainerLayout());
         containers = new HashSet<>();
-        layeredPane = new JLayeredPane();
-        layeredPane.setLayout(new ModalContainerLayout());
+        setLayoutCallback(this);
     }
 
     protected void animatedBegin() {
@@ -31,10 +31,11 @@ public abstract class AbstractModalContainerLayer {
     public abstract void showContainer(boolean show);
 
     public void removeContainer(ModalContainer container) {
+        Option option = container.getOption();
+        boolean visibility = isVisibility(option);
+        boolean fixedLayout = isFixedLayout(option);
+        removeLayer(container, container.getOwner(), visibility, fixedLayout);
         containers.remove(container);
-        layeredPane.remove(container);
-        layeredPane.repaint();
-        layeredPane.revalidate();
     }
 
     public void addModal(Component owner, Modal modal, Option option, String id) {
@@ -44,8 +45,10 @@ public abstract class AbstractModalContainerLayer {
 
     public ModalContainer addModalWithoutShowing(Component owner, Modal modal, Option option, String id) {
         ModalContainer modalContainer = new ModalContainer(this, owner, option, id);
-        layeredPane.setLayer(modalContainer, JLayeredPane.MODAL_LAYER + (option.getLayoutOption().isOnTop() ? 1 : 0));
-        layeredPane.add(modalContainer, 0);
+        int layer = JLayeredPane.MODAL_LAYER + (option.getLayoutOption().isOnTop() ? 1 : 0);
+        boolean visibility = isVisibility(option);
+        boolean fixedLayout = isFixedLayout(option);
+        getLayerAndCreate(owner, visibility, fixedLayout).add(modalContainer, layer, 0);
         modalContainer.initModal(modal);
         modalContainer.setComponentOrientation(layeredPane.getComponentOrientation());
         modal.setId(id);
@@ -81,11 +84,20 @@ public abstract class AbstractModalContainerLayer {
         }
     }
 
-    public void updateModalLayout() {
+    @Override
+    public void updateLayout() {
         layeredPane.revalidate();
         for (ModalContainer con : containers) {
             con.revalidate();
         }
+    }
+
+    @Override
+    public void doLayout() {
+        for (ModalContainer con : containers) {
+            con.revalidate();
+        }
+        layeredPane.repaint();
     }
 
     public boolean checkId(String id) {
@@ -110,11 +122,11 @@ public abstract class AbstractModalContainerLayer {
         return containers;
     }
 
-    public JLayeredPane getLayeredPane() {
-        return layeredPane;
+    private boolean isVisibility(Option option) {
+        return option.getLayoutOption().isRelativeToOwner() && option.getLayoutOption().getRelativeToOwnerType() != LayoutOption.RelativeToOwnerType.RELATIVE_GLOBAL;
     }
 
-    public void initComponentOrientation(ComponentOrientation orientation) {
-        layeredPane.setComponentOrientation(orientation);
+    private boolean isFixedLayout(Option option) {
+        return !option.getLayoutOption().isRelativeToOwner() || option.getLayoutOption().getRelativeToOwnerType() != LayoutOption.RelativeToOwnerType.RELATIVE_CONTAINED;
     }
 }

--- a/modal-dialog/src/main/java/raven/modal/component/AbstractModalContainerLayer.java
+++ b/modal-dialog/src/main/java/raven/modal/component/AbstractModalContainerLayer.java
@@ -82,6 +82,9 @@ public abstract class AbstractModalContainerLayer {
 
     public void updateModalLayout() {
         layeredPane.revalidate();
+        for (ModalContainer con : containers) {
+            con.revalidate();
+        }
     }
 
     public boolean checkId(String id) {

--- a/modal-dialog/src/main/java/raven/modal/component/AbstractModalController.java
+++ b/modal-dialog/src/main/java/raven/modal/component/AbstractModalController.java
@@ -104,7 +104,11 @@ public abstract class AbstractModalController extends JPanel implements Controll
         this.modal = modal;
         modal.setController(this);
         int sliderDuration = option.getSliderDuration();
+        ComponentOrientation orientation = getComponentOrientation();
         SliderTransition sliderTransition = sliderDuration > 0 ? SimpleTransition.get(SimpleTransition.SliderType.FORWARD) : null;
+        if (modal.getComponentOrientation().isLeftToRight() != orientation.isLeftToRight()) {
+            modal.applyComponentOrientation(orientation);
+        }
         panelSlider.addSlide(modal, sliderTransition, sliderDuration);
     }
 

--- a/modal-dialog/src/main/java/raven/modal/component/AbstractRelativeContainer.java
+++ b/modal-dialog/src/main/java/raven/modal/component/AbstractRelativeContainer.java
@@ -1,0 +1,95 @@
+package raven.modal.component;
+
+import raven.modal.layout.RelativeLayout;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Raven
+ */
+public abstract class AbstractRelativeContainer {
+
+    protected final JLayeredPane layeredPane;
+    protected final List<RelativeLayerPane> listLayer;
+    protected final LayoutManager layerLayout;
+    private RelativeLayerPane.LayoutCallback layoutCallback;
+
+    public AbstractRelativeContainer(LayoutManager layerLayout) {
+        this.layerLayout = layerLayout;
+        layeredPane = new JLayeredPane();
+        listLayer = new ArrayList<>();
+        layeredPane.setLayout(new RelativeLayout());
+    }
+
+    protected void setLayoutCallback(RelativeLayerPane.LayoutCallback callback) {
+        this.layoutCallback = callback;
+    }
+
+    protected RelativeLayerPane getLayer(Component owner, boolean controlVisibility, boolean fixedLayout) {
+        for (int i = 0; i < listLayer.size(); i++) {
+            RelativeLayerPane l = listLayer.get(i);
+            if (l.getOwner() == owner
+                    && l.isControlVisibility() == controlVisibility
+                    && l.isFixedLayout() == fixedLayout
+            ) {
+                return l;
+            }
+        }
+        return null;
+    }
+
+    protected void removeLayer(Component component, Component owner, boolean controlVisibility, boolean fixedLayout) {
+        RelativeLayerPane layer = getLayer(owner, controlVisibility, fixedLayout);
+        if (layer != null) {
+            layer.remove(component);
+            if (layer.getComponentCount() == 0) {
+                layeredPane.remove(layer);
+                listLayer.remove(layer);
+            }
+            layer.repaint();
+            layer.revalidate();
+        }
+        layeredPane.repaint();
+        layeredPane.revalidate();
+    }
+
+    protected RelativeLayerPane getLayerAndCreate(Component owner, boolean controlVisibility, boolean fixedLayout) {
+        RelativeLayerPane layer = getLayer(owner, controlVisibility, fixedLayout);
+        if (layer == null) {
+            layer = new RelativeLayerPane(owner, controlVisibility, fixedLayout, layoutCallback);
+            layer.setComponentOrientation(layeredPane.getComponentOrientation());
+            layer.setLayout(layerLayout);
+            listLayer.add(layer);
+            layeredPane.add(layer, JLayeredPane.PALETTE_LAYER, 0);
+        }
+        return layer;
+    }
+
+    public void setEnableHierarchy(boolean enable) {
+        listLayer.forEach(layer -> layer.setEnableHierarchy(enable));
+    }
+
+    public void updateLayout(Component owner) {
+        listLayer.forEach(layer -> {
+            if (layer.getOwner() == owner) {
+                layer.revalidate();
+            }
+        });
+    }
+
+    public void updateLayout() {
+        layeredPane.revalidate();
+        listLayer.forEach(layer -> layer.revalidate());
+    }
+
+    public void initComponentOrientation(ComponentOrientation orientation) {
+        layeredPane.setComponentOrientation(orientation);
+    }
+
+    public JLayeredPane getLayeredPane() {
+        return layeredPane;
+    }
+}

--- a/modal-dialog/src/main/java/raven/modal/component/ModalContainer.java
+++ b/modal-dialog/src/main/java/raven/modal/component/ModalContainer.java
@@ -1,7 +1,9 @@
 package raven.modal.component;
 
 import com.formdev.flatlaf.FlatLaf;
+import com.formdev.flatlaf.ui.FlatUIUtils;
 import com.formdev.flatlaf.util.ColorFunctions;
+import com.formdev.flatlaf.util.UIScale;
 import raven.modal.layout.ModalLayout;
 import raven.modal.option.LayoutOption;
 import raven.modal.option.Option;
@@ -9,7 +11,6 @@ import raven.modal.option.Option;
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.*;
-import java.awt.geom.Rectangle2D;
 
 /**
  * @author Raven
@@ -149,7 +150,12 @@ public class ModalContainer extends JComponent {
                 && !(owner instanceof RootPaneContainer)
         ) {
             Point location = SwingUtilities.convertPoint(owner.getParent(), owner.getLocation(), this);
-            return new Rectangle2D.Double(location.getX(), location.getY(), owner.getWidth(), owner.getHeight());
+            Rectangle rec = new Rectangle(location, owner.getSize());
+            Insets padding = layoutOption.getBackgroundPadding();
+            if (!FlatUIUtils.isInsetsEmpty(padding)) {
+                rec = FlatUIUtils.subtractInsets(rec, UIScale.scale(padding));
+            }
+            return rec;
         }
         return new Rectangle(0, 0, getWidth(), getHeight());
     }

--- a/modal-dialog/src/main/java/raven/modal/component/ModalContainer.java
+++ b/modal-dialog/src/main/java/raven/modal/component/ModalContainer.java
@@ -35,7 +35,7 @@ public class ModalContainer extends JComponent {
     private Component owner;
     private MouseListener mouseListener;
     private ActionListener escapeAction;
-    private HierarchyBoundsListener hierarchyBoundsListener;
+    private ComponentListener componentListener;
     private HierarchyListener hierarchyListener;
     private ModalLayout modalLayout;
     private boolean enableHierarchy = true;
@@ -209,20 +209,20 @@ public class ModalContainer extends JComponent {
     private void installOwnerListener() {
         Option option = getController().getOption();
         if (owner != null && option.getLayoutOption().isRelativeToOwner()) {
-            hierarchyBoundsListener = new HierarchyBoundsListener() {
+            componentListener = new ComponentAdapter() {
                 @Override
-                public void ancestorMoved(HierarchyEvent e) {
+                public void componentResized(ComponentEvent e) {
                     repaint();
                     revalidate();
                 }
 
                 @Override
-                public void ancestorResized(HierarchyEvent e) {
+                public void componentMoved(ComponentEvent e) {
                     repaint();
                     revalidate();
                 }
             };
-            owner.addHierarchyBoundsListener(hierarchyBoundsListener);
+            owner.addComponentListener(componentListener);
 
             if (option.getLayoutOption().getRelativeToOwnerType() == LayoutOption.RelativeToOwnerType.RELATIVE_CONTAINED
                     || (option.isHeavyWeight()
@@ -250,9 +250,9 @@ public class ModalContainer extends JComponent {
 
     private void uninstallOwnerListener() {
         if (owner != null) {
-            if (hierarchyBoundsListener != null) {
-                owner.removeHierarchyBoundsListener(hierarchyBoundsListener);
-                hierarchyBoundsListener = null;
+            if (componentListener != null) {
+                owner.removeComponentListener(componentListener);
+                componentListener = null;
             }
             if (hierarchyListener != null) {
                 owner.removeHierarchyListener(hierarchyListener);

--- a/modal-dialog/src/main/java/raven/modal/component/ModalContainer.java
+++ b/modal-dialog/src/main/java/raven/modal/component/ModalContainer.java
@@ -29,16 +29,17 @@ public class ModalContainer extends JComponent {
         return owner;
     }
 
+    public Option getOption() {
+        return modalController.getOption();
+    }
+
     private final String id;
     private AbstractModalContainerLayer modalContainerLayer;
     private ModalController modalController;
     private Component owner;
     private MouseListener mouseListener;
     private ActionListener escapeAction;
-    private ComponentListener componentListener;
-    private HierarchyListener hierarchyListener;
     private ModalLayout modalLayout;
-    private boolean enableHierarchy = true;
 
     public ModalContainer(AbstractModalContainerLayer modalContainerLayer, Component owner, Option option, String id) {
         this.modalContainerLayer = modalContainerLayer;
@@ -98,10 +99,6 @@ public class ModalContainer extends JComponent {
 
     public ModalController getController() {
         return modalController;
-    }
-
-    protected void setEnableHierarchy(boolean enableHierarchy) {
-        this.enableHierarchy = enableHierarchy;
     }
 
     protected void uninstallOption() {
@@ -204,72 +201,5 @@ public class ModalContainer extends JComponent {
         if (container.getParent() != this) {
             addParentInsets(container.getParent(), insets);
         }
-    }
-
-    private void installOwnerListener() {
-        Option option = getController().getOption();
-        if (owner != null && option.getLayoutOption().isRelativeToOwner()) {
-            componentListener = new ComponentAdapter() {
-                @Override
-                public void componentResized(ComponentEvent e) {
-                    repaint();
-                    revalidate();
-                }
-
-                @Override
-                public void componentMoved(ComponentEvent e) {
-                    repaint();
-                    revalidate();
-                }
-            };
-            owner.addComponentListener(componentListener);
-
-            if (option.getLayoutOption().getRelativeToOwnerType() == LayoutOption.RelativeToOwnerType.RELATIVE_CONTAINED
-                    || (option.isHeavyWeight()
-                    && option.getLayoutOption().getRelativeToOwnerType() == LayoutOption.RelativeToOwnerType.RELATIVE_BOUNDLESS)
-            ) {
-                hierarchyListener = e -> {
-                    if (!enableHierarchy) return;
-                    if ((e.getChangeFlags() & HierarchyEvent.SHOWING_CHANGED) != 0 || (e.getChangeFlags() & HierarchyEvent.DISPLAYABILITY_CHANGED) != 0) {
-                        if (e.getChanged().isShowing()) {
-                            if (owner.isShowing()) {
-                                setVisible(true);
-                            }
-                        } else {
-                            if (!owner.isShowing()) {
-                                setVisible(false);
-                            }
-                        }
-                    }
-                };
-                owner.addHierarchyListener(hierarchyListener);
-                setVisible(owner.isShowing());
-            }
-        }
-    }
-
-    private void uninstallOwnerListener() {
-        if (owner != null) {
-            if (componentListener != null) {
-                owner.removeComponentListener(componentListener);
-                componentListener = null;
-            }
-            if (hierarchyListener != null) {
-                owner.removeHierarchyListener(hierarchyListener);
-                hierarchyListener = null;
-            }
-        }
-    }
-
-    @Override
-    public void addNotify() {
-        super.addNotify();
-        installOwnerListener();
-    }
-
-    @Override
-    public void removeNotify() {
-        super.removeNotify();
-        uninstallOwnerListener();
     }
 }

--- a/modal-dialog/src/main/java/raven/modal/component/ModalContainerLayer.java
+++ b/modal-dialog/src/main/java/raven/modal/component/ModalContainerLayer.java
@@ -34,12 +34,14 @@ public class ModalContainerLayer extends AbstractModalContainerLayer {
 
     @Override
     protected void animatedBegin() {
+        containers.forEach(container -> container.setEnableHierarchy(false));
         showSnapshot();
     }
 
     @Override
     protected void animatedEnd() {
         hideSnapshot();
+        containers.forEach(container -> container.setEnableHierarchy(true));
     }
 
     @Override

--- a/modal-dialog/src/main/java/raven/modal/component/ModalContainerLayer.java
+++ b/modal-dialog/src/main/java/raven/modal/component/ModalContainerLayer.java
@@ -34,14 +34,14 @@ public class ModalContainerLayer extends AbstractModalContainerLayer {
 
     @Override
     protected void animatedBegin() {
-        containers.forEach(container -> container.setEnableHierarchy(false));
+        setEnableHierarchy(false);
         showSnapshot();
     }
 
     @Override
     protected void animatedEnd() {
         hideSnapshot();
-        containers.forEach(container -> container.setEnableHierarchy(true));
+        setEnableHierarchy(true);
     }
 
     @Override
@@ -167,7 +167,7 @@ public class ModalContainerLayer extends AbstractModalContainerLayer {
         if (window != null) {
             stateListener = e -> {
                 if (e.getNewState() == 6 || e.getNewState() == 0) {
-                    SwingUtilities.invokeLater(() -> updateModalLayout());
+                    SwingUtilities.invokeLater(() -> updateLayout());
                 }
             };
             window.addWindowStateListener(stateListener);

--- a/modal-dialog/src/main/java/raven/modal/component/ModalController.java
+++ b/modal-dialog/src/main/java/raven/modal/component/ModalController.java
@@ -101,6 +101,11 @@ public class ModalController extends AbstractModalController {
 
     @Override
     protected void onModalComponentInstalled() {
+        ComponentOrientation orientation = modalContainer.getComponentOrientation();
+        setComponentOrientation(orientation);
+        if (modal.getComponentOrientation().isLeftToRight() != orientation.isLeftToRight()) {
+            modal.applyComponentOrientation(orientation);
+        }
     }
 
     @Override

--- a/modal-dialog/src/main/java/raven/modal/component/ModalWindow.java
+++ b/modal-dialog/src/main/java/raven/modal/component/ModalWindow.java
@@ -37,6 +37,7 @@ public class ModalWindow extends JWindow {
         layeredPane = new JLayeredPane();
         list = new ArrayList<>();
         layeredPane.setLayout(new FullContentLayout());
+        layeredPane.setComponentOrientation(parentWindow.getComponentOrientation());
         setContentPane(layeredPane);
         setBackground(new Color(0, 0, 0, 0));
         installParentWindowListener();
@@ -44,11 +45,13 @@ public class ModalWindow extends JWindow {
 
     public void addToast(ToastHeavyWeightContainerLayer toast) {
         list.add(toast);
+        toast.initComponentOrientation(parentWindow.getComponentOrientation());
         layeredPane.add(toast.getLayeredPane(), JLayeredPane.POPUP_LAYER);
     }
 
     public void addModal(ModalHeavyWeightContainerLayer modal) {
         list.add(modal);
+        modal.initComponentOrientation(parentWindow.getComponentOrientation());
         layeredPane.add(modal.getLayeredPane(), JLayeredPane.MODAL_LAYER + 1);
     }
 

--- a/modal-dialog/src/main/java/raven/modal/component/ModalWindow.java
+++ b/modal-dialog/src/main/java/raven/modal/component/ModalWindow.java
@@ -39,6 +39,7 @@ public class ModalWindow extends JWindow {
         layeredPane.setLayout(new FullContentLayout());
         setContentPane(layeredPane);
         setBackground(new Color(0, 0, 0, 0));
+        setFocusable(true);
         installParentWindowListener();
     }
 

--- a/modal-dialog/src/main/java/raven/modal/component/ModalWindow.java
+++ b/modal-dialog/src/main/java/raven/modal/component/ModalWindow.java
@@ -39,7 +39,6 @@ public class ModalWindow extends JWindow {
         layeredPane.setLayout(new FullContentLayout());
         setContentPane(layeredPane);
         setBackground(new Color(0, 0, 0, 0));
-        setFocusable(true);
         installParentWindowListener();
     }
 
@@ -69,7 +68,9 @@ public class ModalWindow extends JWindow {
 
     public void setShowWindowAndCheck(boolean show) {
         if (show) {
-            setVisible(true);
+            if (!isVisible()) {
+                setVisible(true);
+            }
         } else {
             for (HeavyWindowAction com : list) {
                 if (!com.isEmptyItem()) {

--- a/modal-dialog/src/main/java/raven/modal/component/RelativeLayerPane.java
+++ b/modal-dialog/src/main/java/raven/modal/component/RelativeLayerPane.java
@@ -1,0 +1,103 @@
+package raven.modal.component;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.*;
+
+/**
+ * @author Raven
+ */
+public class RelativeLayerPane extends JLayeredPane {
+
+    public Component getOwner() {
+        return owner;
+    }
+
+    public boolean isControlVisibility() {
+        return controlVisibility;
+    }
+
+    public boolean isFixedLayout() {
+        return fixedLayout;
+    }
+
+    private final Component owner;
+    private final boolean controlVisibility;
+    private final boolean fixedLayout;
+    private HierarchyListener hierarchyListener;
+    private HierarchyBoundsListener hierarchyBoundsListener;
+    private ComponentListener componentListener;
+
+    public RelativeLayerPane(Component owner, boolean controlVisibility, boolean fixedLayout) {
+        this.owner = owner;
+        this.controlVisibility = controlVisibility;
+        this.fixedLayout = fixedLayout;
+    }
+
+    protected void installOwnerListener() {
+        if (owner != null) {
+            componentListener = new ComponentAdapter() {
+                @Override
+                public void componentResized(ComponentEvent e) {
+                    repaint();
+                    revalidate();
+                }
+            };
+            hierarchyBoundsListener = new HierarchyBoundsAdapter() {
+                @Override
+                public void ancestorMoved(HierarchyEvent e) {
+                    repaint();
+                    revalidate();
+                }
+            };
+            owner.addComponentListener(componentListener);
+            owner.addHierarchyBoundsListener(hierarchyBoundsListener);
+            if (controlVisibility) {
+                hierarchyListener = e -> {
+                    if ((e.getChangeFlags() & HierarchyEvent.SHOWING_CHANGED) != 0 || (e.getChangeFlags() & HierarchyEvent.DISPLAYABILITY_CHANGED) != 0) {
+                        if (e.getChanged().isShowing()) {
+                            if (owner.isShowing()) {
+                                setVisible(true);
+                            }
+                        } else {
+                            if (!owner.isShowing()) {
+                                setVisible(false);
+                            }
+                        }
+                    }
+                };
+                owner.addHierarchyListener(hierarchyListener);
+                setVisible(owner.isShowing());
+            }
+        }
+    }
+
+    protected void uninstallOwnerListener() {
+        if (owner != null) {
+            if (componentListener != null) {
+                owner.removeComponentListener(componentListener);
+                componentListener = null;
+            }
+            if (hierarchyBoundsListener != null) {
+                owner.removeHierarchyBoundsListener(hierarchyBoundsListener);
+                hierarchyBoundsListener = null;
+            }
+            if (hierarchyListener != null) {
+                owner.removeHierarchyListener(hierarchyListener);
+                hierarchyListener = null;
+            }
+        }
+    }
+
+    @Override
+    public void addNotify() {
+        super.addNotify();
+        installOwnerListener();
+    }
+
+    @Override
+    public void removeNotify() {
+        super.removeNotify();
+        uninstallOwnerListener();
+    }
+}

--- a/modal-dialog/src/main/java/raven/modal/component/RelativeLayerPane.java
+++ b/modal-dialog/src/main/java/raven/modal/component/RelativeLayerPane.java
@@ -39,14 +39,12 @@ public class RelativeLayerPane extends JLayeredPane {
             componentListener = new ComponentAdapter() {
                 @Override
                 public void componentResized(ComponentEvent e) {
-                    repaint();
                     revalidate();
                 }
             };
             hierarchyBoundsListener = new HierarchyBoundsAdapter() {
                 @Override
                 public void ancestorMoved(HierarchyEvent e) {
-                    repaint();
                     revalidate();
                 }
             };

--- a/modal-dialog/src/main/java/raven/modal/layout/ModalContainerLayout.java
+++ b/modal-dialog/src/main/java/raven/modal/layout/ModalContainerLayout.java
@@ -1,0 +1,75 @@
+package raven.modal.layout;
+
+import raven.modal.component.ModalContainer;
+import raven.modal.option.LayoutOption;
+
+import javax.swing.*;
+import java.awt.*;
+
+/**
+ * @author Raven
+ */
+public class ModalContainerLayout implements LayoutManager {
+
+    public ModalContainerLayout() {
+    }
+
+    @Override
+    public void addLayoutComponent(String name, Component comp) {
+    }
+
+    @Override
+    public void removeLayoutComponent(Component comp) {
+    }
+
+    @Override
+    public Dimension preferredLayoutSize(Container parent) {
+        synchronized (parent.getTreeLock()) {
+            return new Dimension(0, 0);
+        }
+    }
+
+    @Override
+    public Dimension minimumLayoutSize(Container parent) {
+        synchronized (parent.getTreeLock()) {
+            return new Dimension(0, 0);
+        }
+    }
+
+    @Override
+    public void layoutContainer(Container parent) {
+        synchronized (parent.getTreeLock()) {
+            Insets insets = parent.getInsets();
+            int x = insets.left;
+            int y = insets.top;
+            int width = parent.getWidth() - (insets.left + insets.right);
+            int height = parent.getHeight() - (insets.top + insets.bottom);
+            int count = parent.getComponentCount();
+            for (int i = 0; i < count; i++) {
+                Component com = parent.getComponent(i);
+                if (com instanceof ModalContainer) {
+                    ModalContainer container = (ModalContainer) com;
+                    if (isUseOwnerBounds(container)) {
+                        container.setBounds(getOwnerBounds(parent, container));
+                    } else {
+                        container.setBounds(x, y, width, height);
+                    }
+                }
+            }
+        }
+    }
+
+    private boolean isUseOwnerBounds(ModalContainer container) {
+        LayoutOption option = container.getController().getOption().getLayoutOption();
+        Component owner = container.getOwner();
+        return option.isRelativeToOwner()
+                && option.getRelativeToOwnerType() == LayoutOption.RelativeToOwnerType.RELATIVE_CONTAINED
+                && !(owner instanceof RootPaneContainer);
+    }
+
+    private Rectangle getOwnerBounds(Container parent, ModalContainer container) {
+        Component owner = container.getOwner();
+        Point ownerLocation = SwingUtilities.convertPoint(owner.getParent(), owner.getLocation(), parent);
+        return new Rectangle(ownerLocation, owner.getSize());
+    }
+}

--- a/modal-dialog/src/main/java/raven/modal/layout/ModalContainerLayout.java
+++ b/modal-dialog/src/main/java/raven/modal/layout/ModalContainerLayout.java
@@ -1,5 +1,7 @@
 package raven.modal.layout;
 
+import com.formdev.flatlaf.ui.FlatUIUtils;
+import com.formdev.flatlaf.util.UIScale;
 import raven.modal.component.ModalContainer;
 import raven.modal.option.LayoutOption;
 
@@ -49,11 +51,17 @@ public class ModalContainerLayout implements LayoutManager {
                 Component com = parent.getComponent(i);
                 if (com instanceof ModalContainer) {
                     ModalContainer container = (ModalContainer) com;
+                    Rectangle bound;
                     if (isUseOwnerBounds(container)) {
-                        container.setBounds(getOwnerBounds(parent, container));
+                        bound = getOwnerBounds(parent, container);
                     } else {
-                        container.setBounds(x, y, width, height);
+                        bound = new Rectangle(x, y, width, height);
                     }
+                    Insets backgroundPadding = container.getController().getOption().getLayoutOption().getBackgroundPadding();
+                    if (!FlatUIUtils.isInsetsEmpty(backgroundPadding)) {
+                        bound = FlatUIUtils.subtractInsets(bound, UIScale.scale(backgroundPadding));
+                    }
+                    container.setBounds(bound);
                 }
             }
         }

--- a/modal-dialog/src/main/java/raven/modal/layout/ModalContainerLayout.java
+++ b/modal-dialog/src/main/java/raven/modal/layout/ModalContainerLayout.java
@@ -3,9 +3,7 @@ package raven.modal.layout;
 import com.formdev.flatlaf.ui.FlatUIUtils;
 import com.formdev.flatlaf.util.UIScale;
 import raven.modal.component.ModalContainer;
-import raven.modal.option.LayoutOption;
 
-import javax.swing.*;
 import java.awt.*;
 
 /**
@@ -51,13 +49,8 @@ public class ModalContainerLayout implements LayoutManager {
                 Component com = parent.getComponent(i);
                 if (com instanceof ModalContainer) {
                     ModalContainer container = (ModalContainer) com;
-                    Rectangle bound;
-                    if (isUseOwnerBounds(container)) {
-                        bound = getOwnerBounds(parent, container);
-                    } else {
-                        bound = new Rectangle(x, y, width, height);
-                    }
-                    Insets backgroundPadding = container.getController().getOption().getLayoutOption().getBackgroundPadding();
+                    Rectangle bound = new Rectangle(x, y, width, height);
+                    Insets backgroundPadding = container.getOption().getLayoutOption().getBackgroundPadding();
                     if (!FlatUIUtils.isInsetsEmpty(backgroundPadding)) {
                         bound = FlatUIUtils.subtractInsets(bound, UIScale.scale(backgroundPadding));
                     }
@@ -65,19 +58,5 @@ public class ModalContainerLayout implements LayoutManager {
                 }
             }
         }
-    }
-
-    private boolean isUseOwnerBounds(ModalContainer container) {
-        LayoutOption option = container.getController().getOption().getLayoutOption();
-        Component owner = container.getOwner();
-        return option.isRelativeToOwner()
-                && option.getRelativeToOwnerType() == LayoutOption.RelativeToOwnerType.RELATIVE_CONTAINED
-                && !(owner instanceof RootPaneContainer);
-    }
-
-    private Rectangle getOwnerBounds(Container parent, ModalContainer container) {
-        Component owner = container.getOwner();
-        Point ownerLocation = SwingUtilities.convertPoint(owner.getParent(), owner.getLocation(), parent);
-        return new Rectangle(ownerLocation, owner.getSize());
     }
 }

--- a/modal-dialog/src/main/java/raven/modal/layout/OptionLayoutUtils.java
+++ b/modal-dialog/src/main/java/raven/modal/layout/OptionLayoutUtils.java
@@ -18,7 +18,7 @@ public class OptionLayoutUtils {
         Insets parentInsert = parent.getInsets();
         Insets insets = layoutOption.getMargin();
         Dimension defaultComSize = getComponentSize(parent, insets);
-        if (layoutOption.isRelativeToOwner()) {
+        if (layoutOption.isRelativeToOwner() && layoutOption.getRelativeToOwnerType() != LayoutOption.RelativeToOwnerType.RELATIVE_CONTAINED) {
             insets = getOwnerInsert(parent, owner, insets);
         }
         insets = FlatUIUtils.addInsets(parentInsert, UIScale.scale(insets));

--- a/modal-dialog/src/main/java/raven/modal/layout/RelativeLayout.java
+++ b/modal-dialog/src/main/java/raven/modal/layout/RelativeLayout.java
@@ -1,0 +1,68 @@
+package raven.modal.layout;
+
+import raven.modal.component.RelativeLayerPane;
+
+import javax.swing.*;
+import java.awt.*;
+
+/**
+ * @author Raven
+ */
+public class RelativeLayout implements LayoutManager {
+
+    public RelativeLayout() {
+    }
+
+    @Override
+    public void addLayoutComponent(String name, Component comp) {
+    }
+
+    @Override
+    public void removeLayoutComponent(Component comp) {
+    }
+
+    @Override
+    public Dimension preferredLayoutSize(Container parent) {
+        synchronized (parent.getTreeLock()) {
+            return new Dimension(0, 0);
+        }
+    }
+
+    @Override
+    public Dimension minimumLayoutSize(Container parent) {
+        synchronized (parent.getTreeLock()) {
+            return new Dimension(0, 0);
+        }
+    }
+
+    @Override
+    public void layoutContainer(Container parent) {
+        synchronized (parent.getTreeLock()) {
+            Insets insets = parent.getInsets();
+            int x = insets.left;
+            int y = insets.top;
+            int width = parent.getWidth() - (insets.left + insets.right);
+            int height = parent.getHeight() - (insets.top + insets.bottom);
+            int count = parent.getComponentCount();
+            for (int i = 0; i < count; i++) {
+                Component com = parent.getComponent(i);
+                if (com instanceof RelativeLayerPane) {
+                    RelativeLayerPane layer = (RelativeLayerPane) com;
+                    Rectangle bound;
+                    if (layer.isFixedLayout()) {
+                        bound = new Rectangle(x, y, width, height);
+                    } else {
+                        bound = getOwnerBounds(parent, layer);
+                    }
+                    layer.setBounds(bound);
+                }
+            }
+        }
+    }
+
+    private Rectangle getOwnerBounds(Container parent, RelativeLayerPane container) {
+        Component owner = container.getOwner();
+        Point ownerLocation = SwingUtilities.convertPoint(owner.getParent(), owner.getLocation(), parent);
+        return new Rectangle(ownerLocation, owner.getSize());
+    }
+}

--- a/modal-dialog/src/main/java/raven/modal/option/LayoutOption.java
+++ b/modal-dialog/src/main/java/raven/modal/option/LayoutOption.java
@@ -55,7 +55,8 @@ public class LayoutOption {
         return onTop;
     }
 
-    private LayoutOption(DynamicSize location, Insets margin, Insets backgroundPadding, DynamicSize size, DynamicSize animateDistance, RelativeToOwnerType relativeToOwnerType, boolean relativeToOwner, float animateScale, boolean onTop) {
+    private LayoutOption(Location horizontalLocation, DynamicSize location, Insets margin, Insets backgroundPadding, DynamicSize size, DynamicSize animateDistance, RelativeToOwnerType relativeToOwnerType, boolean relativeToOwner, float animateScale, boolean onTop) {
+        this.horizontalLocation = horizontalLocation;
         this.location = location;
         this.margin = margin;
         this.backgroundPadding = backgroundPadding;
@@ -163,7 +164,7 @@ public class LayoutOption {
     }
 
     public LayoutOption copy() {
-        return new LayoutOption(location, copyInsets(margin), copyInsets(backgroundPadding), new DynamicSize(size), new DynamicSize(animateDistance), relativeToOwnerType, relativeToOwner, animateScale, onTop);
+        return new LayoutOption(horizontalLocation, location, copyInsets(margin), copyInsets(backgroundPadding), new DynamicSize(size), new DynamicSize(animateDistance), relativeToOwnerType, relativeToOwner, animateScale, onTop);
     }
 
     private Insets copyInsets(Insets insets) {

--- a/modal-dialog/src/main/java/raven/modal/option/LayoutOption.java
+++ b/modal-dialog/src/main/java/raven/modal/option/LayoutOption.java
@@ -156,7 +156,7 @@ public class LayoutOption {
 
     /**
      * RELATIVE_CONTAINED: Modal and background are confined to the owner's bounds and track the owner's visibility. (default)
-     * RELATIVE_GLOBAL: Background spans the entire window.
+     * RELATIVE_GLOBAL: Background spans the entire window and does not track the owner's visibility
      * RELATIVE_BOUNDLESS: Background covers the owner, but the modal can extend outside the owner. Tracks owner's visibility. (requires heavyWeight = true)
      */
     public enum RelativeToOwnerType {

--- a/modal-dialog/src/main/java/raven/modal/option/LayoutOption.java
+++ b/modal-dialog/src/main/java/raven/modal/option/LayoutOption.java
@@ -35,6 +35,10 @@ public class LayoutOption {
         return animateDistance;
     }
 
+    public RelativeToOwnerType getRelativeToOwnerType() {
+        return relativeToOwnerType;
+    }
+
     public boolean isRelativeToOwner() {
         return relativeToOwner;
     }
@@ -47,11 +51,12 @@ public class LayoutOption {
         return onTop;
     }
 
-    private LayoutOption(DynamicSize location, Insets margin, DynamicSize size, DynamicSize animateDistance, boolean relativeToOwner, float animateScale, boolean onTop) {
+    private LayoutOption(DynamicSize location, Insets margin, DynamicSize size, DynamicSize animateDistance, RelativeToOwnerType relativeToOwnerType, boolean relativeToOwner, float animateScale, boolean onTop) {
         this.location = location;
         this.margin = margin;
         this.size = size;
         this.animateDistance = animateDistance;
+        this.relativeToOwnerType = relativeToOwnerType;
         this.relativeToOwner = relativeToOwner;
         this.animateScale = animateScale;
         this.onTop = onTop;
@@ -66,6 +71,7 @@ public class LayoutOption {
     private Insets margin = new Insets(7, 7, 7, 7);
     private DynamicSize size = new DynamicSize(-1, -1);
     private DynamicSize animateDistance = new DynamicSize(0, 20);
+    private RelativeToOwnerType relativeToOwnerType = RelativeToOwnerType.RELATIVE_CONTAINED;
     private boolean relativeToOwner;
     private float animateScale;
     private boolean onTop = false;
@@ -108,6 +114,11 @@ public class LayoutOption {
         return this;
     }
 
+    public LayoutOption setRelativeToOwnerType(RelativeToOwnerType relativeToOwnerType) {
+        this.relativeToOwnerType = relativeToOwnerType;
+        return this;
+    }
+
     public LayoutOption setRelativeToOwner(boolean relativeToOwner) {
         this.relativeToOwner = relativeToOwner;
         return this;
@@ -126,7 +137,16 @@ public class LayoutOption {
         return this;
     }
 
+    /**
+     * RELATIVE_CONTAINED: Modal and background are confined to the owner's bounds and track the owner's visibility. (default)
+     * RELATIVE_GLOBAL: Background spans the entire window.
+     * RELATIVE_BOUNDLESS: Background covers the owner, but the modal can extend outside the owner. Tracks owner's visibility. (requires heavyWeight = true)
+     */
+    public enum RelativeToOwnerType {
+        RELATIVE_CONTAINED, RELATIVE_GLOBAL, RELATIVE_BOUNDLESS
+    }
+
     public LayoutOption copy() {
-        return new LayoutOption(location, new Insets(margin.top, margin.left, margin.bottom, margin.right), new DynamicSize(size), new DynamicSize(animateDistance), relativeToOwner, animateScale, onTop);
+        return new LayoutOption(location, new Insets(margin.top, margin.left, margin.bottom, margin.right), new DynamicSize(size), new DynamicSize(animateDistance), relativeToOwnerType, relativeToOwner, animateScale, onTop);
     }
 }

--- a/modal-dialog/src/main/java/raven/modal/option/LayoutOption.java
+++ b/modal-dialog/src/main/java/raven/modal/option/LayoutOption.java
@@ -27,6 +27,10 @@ public class LayoutOption {
         return margin;
     }
 
+    public Insets getBackgroundPadding() {
+        return backgroundPadding;
+    }
+
     public DynamicSize getSize() {
         return size;
     }
@@ -51,9 +55,10 @@ public class LayoutOption {
         return onTop;
     }
 
-    private LayoutOption(DynamicSize location, Insets margin, DynamicSize size, DynamicSize animateDistance, RelativeToOwnerType relativeToOwnerType, boolean relativeToOwner, float animateScale, boolean onTop) {
+    private LayoutOption(DynamicSize location, Insets margin, Insets backgroundPadding, DynamicSize size, DynamicSize animateDistance, RelativeToOwnerType relativeToOwnerType, boolean relativeToOwner, float animateScale, boolean onTop) {
         this.location = location;
         this.margin = margin;
+        this.backgroundPadding = backgroundPadding;
         this.size = size;
         this.animateDistance = animateDistance;
         this.relativeToOwnerType = relativeToOwnerType;
@@ -69,6 +74,7 @@ public class LayoutOption {
     private Location horizontalLocation = Location.CENTER;
     private DynamicSize location = new DynamicSize(horizontalLocation.getValue(), Location.CENTER.getValue());
     private Insets margin = new Insets(7, 7, 7, 7);
+    private Insets backgroundPadding = new Insets(0, 0, 0, 0);
     private DynamicSize size = new DynamicSize(-1, -1);
     private DynamicSize animateDistance = new DynamicSize(0, 20);
     private RelativeToOwnerType relativeToOwnerType = RelativeToOwnerType.RELATIVE_CONTAINED;
@@ -101,6 +107,16 @@ public class LayoutOption {
 
     public LayoutOption setMargin(int margin) {
         this.margin = new Insets(margin, margin, margin, margin);
+        return this;
+    }
+
+    public LayoutOption setBackgroundPadding(int top, int left, int bottom, int right) {
+        this.backgroundPadding = new Insets(top, left, bottom, right);
+        return this;
+    }
+
+    public LayoutOption setBackgroundPadding(int adding) {
+        this.backgroundPadding = new Insets(adding, adding, adding, adding);
         return this;
     }
 
@@ -147,6 +163,10 @@ public class LayoutOption {
     }
 
     public LayoutOption copy() {
-        return new LayoutOption(location, new Insets(margin.top, margin.left, margin.bottom, margin.right), new DynamicSize(size), new DynamicSize(animateDistance), relativeToOwnerType, relativeToOwner, animateScale, onTop);
+        return new LayoutOption(location, copyInsets(margin), copyInsets(backgroundPadding), new DynamicSize(size), new DynamicSize(animateDistance), relativeToOwnerType, relativeToOwner, animateScale, onTop);
+    }
+
+    private Insets copyInsets(Insets insets) {
+        return new Insets(insets.top, insets.left, insets.bottom, insets.right);
     }
 }

--- a/modal-dialog/src/main/java/raven/modal/toast/AbstractToastContainerLayer.java
+++ b/modal-dialog/src/main/java/raven/modal/toast/AbstractToastContainerLayer.java
@@ -50,6 +50,7 @@ public abstract class AbstractToastContainerLayer {
         if (layer == null) {
             layer = new RelativeLayerPane(toastPanel.getOwner(), controlVisibility, fixedLayout);
             layer.setLayout(new ToastLayout());
+            layer.setComponentOrientation(layeredPane.getComponentOrientation());
             listToastLayer.add(layer);
             layeredPane.add(layer, JLayeredPane.MODAL_LAYER, 0);
         }
@@ -142,6 +143,10 @@ public abstract class AbstractToastContainerLayer {
     public void revalidateAll() {
         layeredPane.revalidate();
         listToastLayer.forEach(layer -> layer.revalidate());
+    }
+
+    public void initComponentOrientation(ComponentOrientation orientation) {
+        layeredPane.setComponentOrientation(orientation);
     }
 
     public List<ToastPanel> getToastPanels() {

--- a/modal-dialog/src/main/java/raven/modal/toast/AbstractToastContainerLayer.java
+++ b/modal-dialog/src/main/java/raven/modal/toast/AbstractToastContainerLayer.java
@@ -1,7 +1,11 @@
 package raven.modal.toast;
 
+import raven.modal.component.RelativeLayerPane;
+import raven.modal.layout.RelativeLayout;
 import raven.modal.layout.ToastLayout;
+import raven.modal.toast.option.ToastLayoutOption;
 import raven.modal.toast.option.ToastLocation;
+import raven.modal.toast.option.ToastOption;
 
 import javax.swing.*;
 import java.awt.*;
@@ -14,24 +18,65 @@ import java.util.List;
 public abstract class AbstractToastContainerLayer {
 
     protected final List<ToastPanel> toastPanels;
+    protected final List<RelativeLayerPane> listToastLayer;
     protected final JLayeredPane layeredPane;
 
     public abstract void showContainer(boolean show);
 
     public AbstractToastContainerLayer() {
         toastPanels = new ArrayList<>();
+        listToastLayer = new ArrayList<>();
         layeredPane = new JLayeredPane();
-        layeredPane.setLayout(new ToastLayout());
+        layeredPane.setLayout(new RelativeLayout());
     }
 
-    public void add(Component component) {
-        layeredPane.add(component, 0);
+    private RelativeLayerPane getLayer(Component owner, boolean controlVisibility, boolean fixedLayout) {
+        for (int i = 0; i < listToastLayer.size(); i++) {
+            RelativeLayerPane l = listToastLayer.get(i);
+            if (l.getOwner() == owner
+                    && l.isControlVisibility() == controlVisibility
+                    && l.isFixedLayout() == fixedLayout
+            ) {
+                return l;
+            }
+        }
+        return null;
     }
 
-    public void remove(Component component) {
-        layeredPane.remove(component);
-        layeredPane.repaint();
-        layeredPane.revalidate();
+    private RelativeLayerPane getToastLayer(ToastPanel toastPanel) {
+        boolean controlVisibility = isVisibility(toastPanel.getOption());
+        boolean fixedLayout = isFixedLayout(toastPanel.getOption());
+        RelativeLayerPane layer = getLayer(toastPanel.getOwner(), controlVisibility, fixedLayout);
+        if (layer == null) {
+            layer = new RelativeLayerPane(toastPanel.getOwner(), controlVisibility, fixedLayout);
+            layer.setLayout(new ToastLayout());
+            listToastLayer.add(layer);
+            layeredPane.add(layer, JLayeredPane.MODAL_LAYER, 0);
+        }
+        return layer;
+    }
+
+    public void add(ToastPanel toastPanel) {
+        getToastLayer(toastPanel).add(toastPanel, 0);
+    }
+
+    public void remove(ToastPanel toastPanel) {
+        toastPanels.remove(toastPanel);
+        ToastOption option = toastPanel.getOption();
+        RelativeLayerPane layer = getLayer(toastPanel.getOwner(), isVisibility(option), isFixedLayout(option));
+        if (layer != null) {
+            layer.remove(toastPanel);
+        }
+        if (layer.getComponentCount() == 0) {
+            layeredPane.remove(layer);
+            listToastLayer.remove(layer);
+        }
+        layer.repaint();
+        layer.revalidate();
+
+        if (toastPanels.isEmpty()) {
+            showContainer(false);
+        }
     }
 
     public void addToastPanel(ToastPanel toastPanel) {
@@ -39,15 +84,6 @@ public abstract class AbstractToastContainerLayer {
         toastPanel.revalidate();
         toastPanel.repaint();
         showContainer(true);
-    }
-
-    public void removeToastPanel(ToastPanel toastPanel) {
-        if (toastPanels != null) {
-            toastPanels.remove(toastPanel);
-            if (toastPanels.isEmpty()) {
-                showContainer(false);
-            }
-        }
     }
 
     public void closeAll() {
@@ -95,11 +131,32 @@ public abstract class AbstractToastContainerLayer {
         }
     }
 
+    public void revalidate(Component owner) {
+        listToastLayer.forEach(layer -> {
+            if (layer.getOwner() == owner) {
+                layer.revalidate();
+            }
+        });
+    }
+
+    public void revalidateAll() {
+        layeredPane.revalidate();
+        listToastLayer.forEach(layer -> layer.revalidate());
+    }
+
     public List<ToastPanel> getToastPanels() {
         return toastPanels;
     }
 
     public JLayeredPane getLayeredPane() {
         return layeredPane;
+    }
+
+    private boolean isVisibility(ToastOption option) {
+        return option.getLayoutOption().isRelativeToOwner() && option.getLayoutOption().getRelativeToOwnerType() != ToastLayoutOption.RelativeToOwnerType.RELATIVE_GLOBAL;
+    }
+
+    private boolean isFixedLayout(ToastOption option) {
+        return !option.getLayoutOption().isRelativeToOwner() || option.getLayoutOption().getRelativeToOwnerType() != ToastLayoutOption.RelativeToOwnerType.RELATIVE_CONTAINED;
     }
 }

--- a/modal-dialog/src/main/java/raven/modal/toast/ToastContainerLayer.java
+++ b/modal-dialog/src/main/java/raven/modal/toast/ToastContainerLayer.java
@@ -43,7 +43,7 @@ public class ToastContainerLayer extends AbstractToastContainerLayer {
                 if (e.getNewState() == 6 || e.getNewState() == 0) {
                     SwingUtilities.invokeLater(() -> {
                         if (map.containsKey(rootPaneContainer)) {
-                            map.get(rootPaneContainer).revalidateAll();
+                            map.get(rootPaneContainer).updateLayout();
                         }
                     });
                 }

--- a/modal-dialog/src/main/java/raven/modal/toast/ToastContainerLayer.java
+++ b/modal-dialog/src/main/java/raven/modal/toast/ToastContainerLayer.java
@@ -43,7 +43,7 @@ public class ToastContainerLayer extends AbstractToastContainerLayer {
                 if (e.getNewState() == 6 || e.getNewState() == 0) {
                     SwingUtilities.invokeLater(() -> {
                         if (map.containsKey(rootPaneContainer)) {
-                            map.get(rootPaneContainer).getLayeredPane().revalidate();
+                            map.get(rootPaneContainer).revalidateAll();
                         }
                     });
                 }

--- a/modal-dialog/src/main/java/raven/modal/toast/ToastHeavyWeight.java
+++ b/modal-dialog/src/main/java/raven/modal/toast/ToastHeavyWeight.java
@@ -28,7 +28,7 @@ public class ToastHeavyWeight {
 
     public void updateLayout() {
         for (ToastHeavyWeightContainerLayer com : map.values()) {
-            com.getLayeredPane().revalidate();
+            com.revalidateAll();
         }
     }
 

--- a/modal-dialog/src/main/java/raven/modal/toast/ToastHeavyWeight.java
+++ b/modal-dialog/src/main/java/raven/modal/toast/ToastHeavyWeight.java
@@ -28,7 +28,7 @@ public class ToastHeavyWeight {
 
     public void updateLayout() {
         for (ToastHeavyWeightContainerLayer com : map.values()) {
-            com.revalidateAll();
+            com.updateLayout();
         }
     }
 

--- a/modal-dialog/src/main/java/raven/modal/toast/ToastPanel.java
+++ b/modal-dialog/src/main/java/raven/modal/toast/ToastPanel.java
@@ -348,7 +348,7 @@ public class ToastPanel extends JPanel {
                     @Override
                     public void timingEvent(float v) {
                         animate = showing ? v : 1f - v;
-                        toastContainerLayer.revalidate(owner);
+                        toastContainerLayer.updateLayout(owner);
                     }
 
                     @Override

--- a/modal-dialog/src/main/java/raven/modal/toast/ToastPanel.java
+++ b/modal-dialog/src/main/java/raven/modal/toast/ToastPanel.java
@@ -31,6 +31,10 @@ public class ToastPanel extends JPanel {
         return owner;
     }
 
+    public ToastOption getOption() {
+        return toastData.getOption();
+    }
+
     private final AbstractToastContainerLayer toastContainerLayer;
     private final Component owner;
     private ToastData toastData;
@@ -93,7 +97,7 @@ public class ToastPanel extends JPanel {
         }
     }
 
-    public Component createToast() {
+    public ToastPanel createToast() {
         ThemesData themesData = toastData.getThemes();
         installDefault(themesData);
         Icon icon = createIcon(themesData);
@@ -107,7 +111,7 @@ public class ToastPanel extends JPanel {
         return this;
     }
 
-    public Component createToastPromise(ToastPromise promise) {
+    public ToastPanel createToastPromise(ToastPromise promise) {
         this.toastPromise = promise;
         ThemesData themesData = toastData.getThemes();
         installDefault(themesData);
@@ -121,7 +125,7 @@ public class ToastPanel extends JPanel {
         return this;
     }
 
-    public Component createToastCustom(Component component) {
+    public ToastPanel createToastCustom(Component component) {
         content = new ToastContent(new MigLayout(), toastData);
         if (component instanceof ToastCustom) {
             ToastCustom toastCustom = (ToastCustom) component;
@@ -344,7 +348,7 @@ public class ToastPanel extends JPanel {
                     @Override
                     public void timingEvent(float v) {
                         animate = showing ? v : 1f - v;
-                        toastContainerLayer.getLayeredPane().revalidate();
+                        toastContainerLayer.revalidate(owner);
                     }
 
                     @Override
@@ -434,7 +438,6 @@ public class ToastPanel extends JPanel {
     }
 
     private void removeToast() {
-        toastContainerLayer.removeToastPanel(this);
         if (mouseListener != null) {
             content.removeMouseListener(mouseListener);
             if (textMessage != null) {
@@ -447,8 +450,8 @@ public class ToastPanel extends JPanel {
             toastPromise.setDone(true);
             toastPromise.reject();
         }
-        toastData = null;
         toastContainerLayer.remove(this);
+        toastData = null;
         content = null;
         textMessage = null;
         labelIcon = null;

--- a/modal-dialog/src/main/java/raven/modal/toast/option/ToastLayoutOption.java
+++ b/modal-dialog/src/main/java/raven/modal/toast/option/ToastLayoutOption.java
@@ -52,7 +52,7 @@ public class ToastLayoutOption {
     private ToastLocation location = ToastLocation.TOP_CENTER;
     private DynamicSize locationSize;
     private ToastDirection direction;
-    private RelativeToOwnerType relativeToOwnerType;
+    private RelativeToOwnerType relativeToOwnerType = RelativeToOwnerType.RELATIVE_CONTAINED;
     private boolean relativeToOwner;
     private Insets margin = new Insets(7, 7, 7, 7);
 

--- a/modal-dialog/src/main/java/raven/modal/toast/option/ToastLayoutOption.java
+++ b/modal-dialog/src/main/java/raven/modal/toast/option/ToastLayoutOption.java
@@ -23,6 +23,10 @@ public class ToastLayoutOption {
         return locationSize;
     }
 
+    public RelativeToOwnerType getRelativeToOwnerType() {
+        return relativeToOwnerType;
+    }
+
     public boolean isRelativeToOwner() {
         return relativeToOwner;
     }
@@ -34,10 +38,11 @@ public class ToastLayoutOption {
         return location.getDirection();
     }
 
-    private ToastLayoutOption(ToastLocation location, DynamicSize locationSize, ToastDirection direction, boolean relativeToOwner) {
+    private ToastLayoutOption(ToastLocation location, DynamicSize locationSize, ToastDirection direction, RelativeToOwnerType relativeToOwnerType, boolean relativeToOwner) {
         this.location = location;
         this.locationSize = locationSize;
         this.direction = direction;
+        this.relativeToOwnerType = relativeToOwnerType;
         this.relativeToOwner = relativeToOwner;
     }
 
@@ -47,6 +52,7 @@ public class ToastLayoutOption {
     private ToastLocation location = ToastLocation.TOP_CENTER;
     private DynamicSize locationSize;
     private ToastDirection direction;
+    private RelativeToOwnerType relativeToOwnerType;
     private boolean relativeToOwner;
     private Insets margin = new Insets(7, 7, 7, 7);
 
@@ -63,6 +69,11 @@ public class ToastLayoutOption {
 
     public ToastLayoutOption setDirection(ToastDirection direction) {
         this.direction = direction;
+        return this;
+    }
+
+    public ToastLayoutOption setRelativeToOwnerType(RelativeToOwnerType relativeToOwnerType) {
+        this.relativeToOwnerType = relativeToOwnerType;
         return this;
     }
 
@@ -84,7 +95,7 @@ public class ToastLayoutOption {
     public LayoutOption createLayoutOption(Component parent, Component owner) {
         ToastDirection direction = getDirection();
         Insets insets = new Insets(margin.top, margin.left, margin.bottom, margin.right);
-        if (isRelativeToOwner()) {
+        if (owner != null && getRelativeToOwnerType() != RelativeToOwnerType.RELATIVE_CONTAINED) {
             insets = OptionLayoutUtils.getOwnerInsert(parent, owner, insets);
         }
         LayoutOption layoutOption = new LayoutOption()
@@ -101,7 +112,16 @@ public class ToastLayoutOption {
         return layoutOption;
     }
 
+    /**
+     * RELATIVE_CONTAINED: Toast is confined to the owner's bounds and tracks the owner's visibility. (default)
+     * RELATIVE_GLOBAL: Toast spans the entire window and does not track the owner's visibility
+     * RELATIVE_BOUNDLESS: Toast can extend outside the owner's bounds and tracks the owner's visibility
+     */
+    public enum RelativeToOwnerType {
+        RELATIVE_CONTAINED, RELATIVE_GLOBAL, RELATIVE_BOUNDLESS
+    }
+
     public ToastLayoutOption copy() {
-        return new ToastLayoutOption(location, locationSize, direction, relativeToOwner);
+        return new ToastLayoutOption(location, locationSize, direction, relativeToOwnerType, relativeToOwner);
     }
 }


### PR DESCRIPTION
This PR update added `relativeToOwnerType`. This option work when `relativeToOwner` is set to `true`. 
How to use relativeToOwner option see ` PR #24

This option added to modal dialog and toast and with 3 type:
#### Modal dialog
- `RELATIVE_CONTAINED`: modal and background are confined to the owner's bounds and track the owner's visibility (`default`)
- `RELATIVE_GLOBAL`: background spans the entire window and does not track the owner's visibility
- `RELATIVE_BOUNDLESS`: background covers the owner, but the modal can extend outside the owner. Tracks owner's visibility. (this `RELATIVE_BOUNDLESS` requires `heavyWeight` = `true`)

``` java
// import
import raven.modal.option.LayoutOption;

// create option
Option option = ModalDialog.createOption();

// apply type
option.getLayoutOption()
        .setRelativeToOwner(true)
        .setRelativeToOwnerType(LayoutOption.RelativeToOwnerType.RELATIVE_GLOBAL);
```

#### Toast
- `RELATIVE_CONTAINED`: toast is confined to the owner's bounds and tracks the owner's visibility. (`default`)
- `RELATIVE_GLOBAL`: toast spans the entire window and does not track the owner's visibility
- `RELATIVE_BOUNDLESS`: toast can extend outside the owner's bounds and tracks the owner's visibility

``` java
// import
import raven.modal.toast.option.ToastLayoutOption;

// create option
ToastOption option = Toast.createOption();

// apply type
option.getLayoutOption()
        .setRelativeToOwner(true)
        .setRelativeToOwnerType(ToastLayoutOption.RelativeToOwnerType.RELATIVE_CONTAINED);
```

_**Tracks the owner's visibility** mean: when the owner component is hide or invisible the modal and toast are also hidden._

#### Screenshot

`RELATIVE_CONTAINED`

![modal contained](https://github.com/user-attachments/assets/5367ac9b-3f92-4129-96a0-9751054908cb)

`RELATIVE_GLOBAL`

![modal global](https://github.com/user-attachments/assets/d6371f7d-da60-4ad4-8645-66b7cd844f78)

`RELATIVE_BOUNDLESS`

![modal boundless](https://github.com/user-attachments/assets/3758a52d-45a2-4bb2-b557-9d3e5cc40bab)

