### PR TITLE
Modal: add `movable` option and `overflowAlignmentAuto`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,23 @@
     - Add new option `heavyWeight` by default `false` if set to true, the modal and toast will show by create `JWindow`
     - Add new layout option `relativeToOwner` by default `false` if set to true, the location modal and toast will show
       relative to the owner component
+    - Add new option `overflowAlignmentAuto` work when component overflow the container
+        - if `ture` the component adjust to center of container
+        - if `false` the location value `<0.5f` adjust to the left, location value `>0.5f` adjust to the right, location
+          value `0.5f` adjust center
+            - modal: `true` by default
+            - toast: `false` by default
 - Modal dialog
-    - Add new option `relativeToOwnerType` (requires `relativeToOwner` = `true`) with 3 types:
+    - Add new layout option `relativeToOwnerType` (requires `relativeToOwner` = `true`) with 3 types:
         - `RELATIVE_CONTAINED`: modal and background are confined to the owner's bounds and track the owner's
           visibility (`default`)
         - `RELATIVE_GLOBAL`: background spans the entire window and does not track the owner's visibility
         - `RELATIVE_BOUNDLESS`: background covers the owner, but the modal can extend outside the owner. Tracks owner's
           visibility. (requires `heavyWeight` = `true`)
-    - Add new option `backgroundPadding` to padding the background. by default `insets(0,0,0,0)`
+    - Add new layout option `backgroundPadding` to padding the background. by default `insets(0,0,0,0)`
+    - Add new layout option `movable` by default `false` if set to true, the modal can move by mouse drag
 - Toast
-    - Add new option `relativeToOwnerType` (requires `relativeToOwner` = `true`) with 3 types:
+    - Add new layout option `relativeToOwnerType` (requires `relativeToOwner` = `true`) with 3 types:
         - `RELATIVE_CONTAINED`: toast is confined to the owner's bounds and tracks the owner's visibility. (`default`)
         - `RELATIVE_GLOBAL`: toast spans the entire window and does not track the owner's visibility
         - `RELATIVE_BOUNDLESS`: toast can extend outside the owner's bounds and tracks the owner's visibility

--- a/demo/src/main/java/raven/modal/demo/forms/FormModal.java
+++ b/demo/src/main/java/raven/modal/demo/forms/FormModal.java
@@ -115,7 +115,7 @@ public class FormModal extends Form {
         chShadow = new JCheckBox("Shadow border");
         chOpacity = new JCheckBox("Background opacity");
         chScale = new JCheckBox("Animate scale");
-        chHeavyWeight = new JCheckBox("Heavy Weight");
+        chHeavyWeight = new JCheckBox("Heavy weight");
         chRelativeToOwner = new JCheckBox("Relative to owner");
         chMovable = new JCheckBox("Movable");
 

--- a/demo/src/main/java/raven/modal/demo/forms/FormModal.java
+++ b/demo/src/main/java/raven/modal/demo/forms/FormModal.java
@@ -117,6 +117,7 @@ public class FormModal extends Form {
         chScale = new JCheckBox("Animate scale");
         chHeavyWeight = new JCheckBox("Heavy Weight");
         chRelativeToOwner = new JCheckBox("Relative to owner");
+        chMovable = new JCheckBox("Movable");
 
         // event
         chAnimation.addActionListener(e -> {
@@ -135,6 +136,7 @@ public class FormModal extends Form {
         panel.add(chScale);
         panel.add(chHeavyWeight);
         panel.add(chRelativeToOwner);
+        panel.add(chMovable);
 
         return panel;
     }
@@ -250,7 +252,8 @@ public class FormModal extends Form {
                 .setBorderWidth(chBorder.isSelected() ? 1f : 0)
                 .setShadow(chShadow.isSelected() ? BorderOption.Shadow.MEDIUM : BorderOption.Shadow.NONE);
         option.getLayoutOption().setLocation(h, v)
-                .setRelativeToOwner(chRelativeToOwner.isSelected());
+                .setRelativeToOwner(chRelativeToOwner.isSelected())
+                .setMovable(chMovable.isSelected());
         if (scale != 0) {
             option.getLayoutOption().setAnimateDistance(0, 0)
                     .setAnimateScale(scale);
@@ -279,6 +282,7 @@ public class FormModal extends Form {
     private JCheckBox chScale;
     private JCheckBox chHeavyWeight;
     private JCheckBox chRelativeToOwner;
+    private JCheckBox chMovable;
 
     // background click option
     private JRadioButton jrClose;

--- a/demo/src/main/java/raven/modal/demo/forms/FormToast.java
+++ b/demo/src/main/java/raven/modal/demo/forms/FormToast.java
@@ -106,9 +106,9 @@ public class FormToast extends Form {
         chPauseDelayOnHover = new JCheckBox("Pause delay on hover");
         chAutoClose = new JCheckBox("Auto close");
         chCloseOnClick = new JCheckBox("Close on click");
-        chHeavyWeight = new JCheckBox("Heavy Weight");
+        chHeavyWeight = new JCheckBox("Heavy weight");
         chRelativeToOwner = new JCheckBox("Relative to owner");
-        JCheckBox chReverseOrder = new JCheckBox("Reverse Order");
+        JCheckBox chReverseOrder = new JCheckBox("Reverse order");
 
         chAnimation.setSelected(true);
         chPauseDelayOnHover.setSelected(true);

--- a/modal-dialog/src/main/java/raven/modal/ModalDialog.java
+++ b/modal-dialog/src/main/java/raven/modal/ModalDialog.java
@@ -51,9 +51,11 @@ public class ModalDialog {
             throw new IllegalArgumentException("id '" + id + "' already exist");
         }
         SwingUtilities.invokeLater(() -> {
-            boolean isHeavyWeight = option.isHeavyWeight();
-            Component modelOwner = option.getLayoutOption().isRelativeToOwner() ? owner : null;
-            getInstance().getModalContainer(owner, isHeavyWeight).addModal(modelOwner, modal, option, id);
+            // need copy if the option is the default option
+            Option copyOption = option == getDefaultOption() ? option.copy() : option;
+            boolean isHeavyWeight = copyOption.isHeavyWeight();
+            Component modelOwner = copyOption.getLayoutOption().isRelativeToOwner() ? owner : null;
+            getInstance().getModalContainer(owner, isHeavyWeight).addModal(modelOwner, modal, copyOption, id);
         });
     }
 

--- a/modal-dialog/src/main/java/raven/modal/component/AbstractModalController.java
+++ b/modal-dialog/src/main/java/raven/modal/component/AbstractModalController.java
@@ -6,6 +6,7 @@ import raven.modal.option.Option;
 import raven.modal.slider.PanelSlider;
 import raven.modal.slider.SimpleTransition;
 import raven.modal.slider.SliderTransition;
+import raven.modal.utils.ModalMouseMovableListener;
 import raven.modal.utils.ModalUtils;
 
 import javax.swing.*;
@@ -33,9 +34,16 @@ public abstract class AbstractModalController extends JPanel implements Controll
     }
 
     private void init() {
-        // create mouse event to block the component
-        addMouseListener(new MouseAdapter() {
-        });
+        boolean movable = option.getLayoutOption().isMovable();
+        if (movable) {
+            MouseAdapter mouseListener = createMouseMovableListener();
+            addMouseListener(mouseListener);
+            addMouseMotionListener(mouseListener);
+        } else {
+            // create mouse event to block the component
+            addMouseListener(new MouseAdapter() {
+            });
+        }
 
         Insets shadowSize = option.getBorderOption().getShadowSize();
         int minimumSize = ModalUtils.maximumInsets(shadowSize);
@@ -59,6 +67,10 @@ public abstract class AbstractModalController extends JPanel implements Controll
         if (border != null) {
             setBorder(border);
         }
+    }
+
+    protected MouseAdapter createMouseMovableListener() {
+        return new ModalMouseMovableListener(this);
     }
 
     protected void installModalComponent(Modal modal) {
@@ -168,6 +180,8 @@ public abstract class AbstractModalController extends JPanel implements Controll
     public String getId() {
         return modal.getId();
     }
+
+    public abstract ModalContainer getModalContainer();
 
     protected abstract PanelSlider.PaneSliderLayoutSize createSliderLayoutSize();
 

--- a/modal-dialog/src/main/java/raven/modal/component/ModalController.java
+++ b/modal-dialog/src/main/java/raven/modal/component/ModalController.java
@@ -95,6 +95,11 @@ public class ModalController extends AbstractModalController {
     }
 
     @Override
+    public ModalContainer getModalContainer() {
+        return modalContainer;
+    }
+
+    @Override
     protected PanelSlider.PaneSliderLayoutSize createSliderLayoutSize() {
         return (container, component) -> modalContainer.getModalComponentSize(component, container);
     }
@@ -174,9 +179,5 @@ public class ModalController extends AbstractModalController {
 
     public float getAnimated() {
         return animated;
-    }
-
-    public ModalContainer getModalContainer() {
-        return modalContainer;
     }
 }

--- a/modal-dialog/src/main/java/raven/modal/component/SimpleModalBorder.java
+++ b/modal-dialog/src/main/java/raven/modal/component/SimpleModalBorder.java
@@ -12,8 +12,7 @@ import java.awt.*;
 import java.util.function.Consumer;
 
 /**
- * This class contain with title and close button
- * And two action button, ok and close
+ * This class contain with title, action button options and close button
  *
  * @author Raven
  */
@@ -24,7 +23,6 @@ public class SimpleModalBorder extends Modal implements ModalBorderAction {
 
     protected final ModalBorderOption option;
     protected final String title;
-    private final int optionType;
     private Option[] optionsType;
     private final ModalCallback callback;
 
@@ -70,7 +68,6 @@ public class SimpleModalBorder extends Modal implements ModalBorderAction {
         this.component = component;
         this.option = option;
         this.title = title;
-        this.optionType = optionType;
         this.callback = callback;
         if (optionType == -1) {
             this.optionsType = optionsType;

--- a/modal-dialog/src/main/java/raven/modal/layout/OptionLayoutUtils.java
+++ b/modal-dialog/src/main/java/raven/modal/layout/OptionLayoutUtils.java
@@ -44,7 +44,7 @@ public class OptionLayoutUtils {
             lx = lh.getValue();
         }
         DynamicSize size = new DynamicSize(lx, ly);
-        Point point = location(width, height, comSize, size);
+        Point point = location(width, height, comSize, size, layoutOption.isOverflowAlignmentAuto());
         Point animatePoint = getAnimatePoint(comSize, animate, rightToLeft, layoutOption);
         int cx = x + point.x + animatePoint.x;
         int cy = y + point.y + animatePoint.y;
@@ -68,7 +68,7 @@ public class OptionLayoutUtils {
         return new Insets(top, left, bottom, right);
     }
 
-    protected static Point location(int width, int height, Dimension componentSize, DynamicSize size) {
+    protected static Point location(int width, int height, Dimension componentSize, DynamicSize size, boolean overflowAlignmentAuto) {
         Dimension location = size.getSize(new Dimension(width, height));
         double x = location.width;
         double y = location.height;
@@ -79,28 +79,34 @@ public class OptionLayoutUtils {
             y -= componentSize.height / 2f;
         }
         if (!size.isHorizontalCenter()) {
-            if (componentSize.width > width) {
-                x = (width - componentSize.width) / 2;
-            } else {
-                if (x < 0) {
-                    x = 0;
-                } else if (x > width - componentSize.width) {
-                    x = width - componentSize.width;
-                }
-            }
+            x = adjustValue(size.getX(), x, componentSize.width, width, overflowAlignmentAuto);
         }
         if (!size.isVerticalCenter()) {
-            if (componentSize.height > height) {
-                y = (height - componentSize.height) / 2;
-            } else {
-                if (y < 0) {
-                    y = 0;
-                } else if (y > height - componentSize.height) {
-                    y = height - componentSize.height;
-                }
-            }
+            y = adjustValue(size.getY(), y, componentSize.height, height, overflowAlignmentAuto);
         }
         return new Point((int) x, (int) y);
+    }
+
+    protected static double adjustValue(Number location, double value, int componentSize, int containerSize, boolean overflowAlignmentAuto) {
+        if (componentSize > containerSize) {
+            if (overflowAlignmentAuto) {
+                value = (containerSize - componentSize) / 2f;
+            } else {
+                boolean alightRight = location instanceof Float && location.floatValue() > 0.5f;
+                if (alightRight) {
+                    value = containerSize - componentSize;
+                } else {
+                    value = 0;
+                }
+            }
+        } else {
+            if (value < 0) {
+                value = 0;
+            } else if (value > containerSize - componentSize) {
+                value = containerSize - componentSize;
+            }
+        }
+        return value;
     }
 
     protected static Dimension getComponentSize(Component component, int width, int height, float animate, LayoutOption layoutOption) {

--- a/modal-dialog/src/main/java/raven/modal/layout/OptionLayoutUtils.java
+++ b/modal-dialog/src/main/java/raven/modal/layout/OptionLayoutUtils.java
@@ -79,17 +79,25 @@ public class OptionLayoutUtils {
             y -= componentSize.height / 2f;
         }
         if (!size.isHorizontalCenter()) {
-            if (x < 0) {
-                x = 0;
-            } else if (x > width - componentSize.width) {
-                x = width - componentSize.width;
+            if (componentSize.width > width) {
+                x = (width - componentSize.width) / 2;
+            } else {
+                if (x < 0) {
+                    x = 0;
+                } else if (x > width - componentSize.width) {
+                    x = width - componentSize.width;
+                }
             }
         }
         if (!size.isVerticalCenter()) {
-            if (y < 0) {
-                y = 0;
-            } else if (y > height - componentSize.height) {
-                y = height - componentSize.height;
+            if (componentSize.height > height) {
+                y = (height - componentSize.height) / 2;
+            } else {
+                if (y < 0) {
+                    y = 0;
+                } else if (y > height - componentSize.height) {
+                    y = height - componentSize.height;
+                }
             }
         }
         return new Point((int) x, (int) y);

--- a/modal-dialog/src/main/java/raven/modal/layout/ToastLayout.java
+++ b/modal-dialog/src/main/java/raven/modal/layout/ToastLayout.java
@@ -72,7 +72,7 @@ public class ToastLayout implements LayoutManager {
     private float getLayoutY(Container parent, Dimension comSize, LayoutOption layoutOption) {
         int insets = parent.getInsets().top + parent.getInsets().bottom + UIScale.scale(layoutOption.getMargin().top + layoutOption.getMargin().bottom);
         int height = parent.getHeight() - insets;
-        Point point = OptionLayoutUtils.location(0, height, comSize, layoutOption.getLocation());
+        Point point = OptionLayoutUtils.location(0, height, comSize, layoutOption.getLocation(), layoutOption.isOverflowAlignmentAuto());
         return point.y;
     }
 

--- a/modal-dialog/src/main/java/raven/modal/option/LayoutOption.java
+++ b/modal-dialog/src/main/java/raven/modal/option/LayoutOption.java
@@ -47,6 +47,10 @@ public class LayoutOption {
         return relativeToOwner;
     }
 
+    public boolean isOverflowAlignmentAuto() {
+        return overflowAlignmentAuto;
+    }
+
     public boolean isMovable() {
         return movable;
     }
@@ -59,7 +63,7 @@ public class LayoutOption {
         return onTop;
     }
 
-    private LayoutOption(Location horizontalLocation, DynamicSize location, Insets margin, Insets backgroundPadding, DynamicSize size, DynamicSize animateDistance, RelativeToOwnerType relativeToOwnerType, boolean relativeToOwner, boolean movable, float animateScale, boolean onTop) {
+    private LayoutOption(Location horizontalLocation, DynamicSize location, Insets margin, Insets backgroundPadding, DynamicSize size, DynamicSize animateDistance, RelativeToOwnerType relativeToOwnerType, boolean relativeToOwner, boolean overflowAlignmentAuto, boolean movable, float animateScale, boolean onTop) {
         this.horizontalLocation = horizontalLocation;
         this.location = location;
         this.margin = margin;
@@ -68,6 +72,7 @@ public class LayoutOption {
         this.animateDistance = animateDistance;
         this.relativeToOwnerType = relativeToOwnerType;
         this.relativeToOwner = relativeToOwner;
+        this.overflowAlignmentAuto = overflowAlignmentAuto;
         this.movable = movable;
         this.animateScale = animateScale;
         this.onTop = onTop;
@@ -85,6 +90,7 @@ public class LayoutOption {
     private DynamicSize animateDistance = new DynamicSize(0, 20);
     private RelativeToOwnerType relativeToOwnerType = RelativeToOwnerType.RELATIVE_CONTAINED;
     private boolean relativeToOwner;
+    private boolean overflowAlignmentAuto = true;
     private boolean movable;
     private float animateScale;
     private boolean onTop = false;
@@ -147,6 +153,11 @@ public class LayoutOption {
         return this;
     }
 
+    public LayoutOption setOverflowAlignmentAuto(boolean overflowAlignmentAuto) {
+        this.overflowAlignmentAuto = overflowAlignmentAuto;
+        return this;
+    }
+
     public LayoutOption setMovable(boolean movable) {
         this.movable = movable;
         return this;
@@ -175,7 +186,7 @@ public class LayoutOption {
     }
 
     public LayoutOption copy() {
-        return new LayoutOption(horizontalLocation, location, copyInsets(margin), copyInsets(backgroundPadding), new DynamicSize(size), new DynamicSize(animateDistance), relativeToOwnerType, relativeToOwner, movable, animateScale, onTop);
+        return new LayoutOption(horizontalLocation, location, copyInsets(margin), copyInsets(backgroundPadding), new DynamicSize(size), new DynamicSize(animateDistance), relativeToOwnerType, relativeToOwner, overflowAlignmentAuto, movable, animateScale, onTop);
     }
 
     private Insets copyInsets(Insets insets) {

--- a/modal-dialog/src/main/java/raven/modal/option/LayoutOption.java
+++ b/modal-dialog/src/main/java/raven/modal/option/LayoutOption.java
@@ -47,6 +47,10 @@ public class LayoutOption {
         return relativeToOwner;
     }
 
+    public boolean isMovable() {
+        return movable;
+    }
+
     public float getAnimateScale() {
         return animateScale;
     }
@@ -55,7 +59,7 @@ public class LayoutOption {
         return onTop;
     }
 
-    private LayoutOption(Location horizontalLocation, DynamicSize location, Insets margin, Insets backgroundPadding, DynamicSize size, DynamicSize animateDistance, RelativeToOwnerType relativeToOwnerType, boolean relativeToOwner, float animateScale, boolean onTop) {
+    private LayoutOption(Location horizontalLocation, DynamicSize location, Insets margin, Insets backgroundPadding, DynamicSize size, DynamicSize animateDistance, RelativeToOwnerType relativeToOwnerType, boolean relativeToOwner, boolean movable, float animateScale, boolean onTop) {
         this.horizontalLocation = horizontalLocation;
         this.location = location;
         this.margin = margin;
@@ -64,6 +68,7 @@ public class LayoutOption {
         this.animateDistance = animateDistance;
         this.relativeToOwnerType = relativeToOwnerType;
         this.relativeToOwner = relativeToOwner;
+        this.movable = movable;
         this.animateScale = animateScale;
         this.onTop = onTop;
     }
@@ -80,6 +85,7 @@ public class LayoutOption {
     private DynamicSize animateDistance = new DynamicSize(0, 20);
     private RelativeToOwnerType relativeToOwnerType = RelativeToOwnerType.RELATIVE_CONTAINED;
     private boolean relativeToOwner;
+    private boolean movable;
     private float animateScale;
     private boolean onTop = false;
 
@@ -141,6 +147,11 @@ public class LayoutOption {
         return this;
     }
 
+    public LayoutOption setMovable(boolean movable) {
+        this.movable = movable;
+        return this;
+    }
+
     public LayoutOption setOnTop(boolean onTop) {
         this.onTop = onTop;
         return this;
@@ -164,7 +175,7 @@ public class LayoutOption {
     }
 
     public LayoutOption copy() {
-        return new LayoutOption(horizontalLocation, location, copyInsets(margin), copyInsets(backgroundPadding), new DynamicSize(size), new DynamicSize(animateDistance), relativeToOwnerType, relativeToOwner, animateScale, onTop);
+        return new LayoutOption(horizontalLocation, location, copyInsets(margin), copyInsets(backgroundPadding), new DynamicSize(size), new DynamicSize(animateDistance), relativeToOwnerType, relativeToOwner, movable, animateScale, onTop);
     }
 
     private Insets copyInsets(Insets insets) {

--- a/modal-dialog/src/main/java/raven/modal/toast/AbstractToastContainerLayer.java
+++ b/modal-dialog/src/main/java/raven/modal/toast/AbstractToastContainerLayer.java
@@ -7,6 +7,7 @@ import raven.modal.toast.option.ToastLocation;
 import raven.modal.toast.option.ToastOption;
 
 import javax.swing.*;
+import java.awt.*;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -27,14 +28,14 @@ public abstract class AbstractToastContainerLayer extends AbstractRelativeContai
     public void add(ToastPanel toastPanel) {
         ToastOption option = toastPanel.getOption();
         boolean visibility = isVisibility(option);
-        boolean fixedLayout = isFixedLayout(option);
+        boolean fixedLayout = isFixedLayout(option, toastPanel.getOwner());
         getLayerAndCreate(toastPanel.getOwner(), visibility, fixedLayout).add(toastPanel, JLayeredPane.PALETTE_LAYER, 0);
     }
 
     public void remove(ToastPanel toastPanel) {
         ToastOption option = toastPanel.getOption();
         boolean visibility = isVisibility(option);
-        boolean fixedLayout = isFixedLayout(option);
+        boolean fixedLayout = isFixedLayout(option, toastPanel.getOwner());
         removeLayer(toastPanel, toastPanel.getOwner(), visibility, fixedLayout);
         toastPanels.remove(toastPanel);
         if (toastPanels.isEmpty()) {
@@ -102,7 +103,7 @@ public abstract class AbstractToastContainerLayer extends AbstractRelativeContai
         return option.getLayoutOption().isRelativeToOwner() && option.getLayoutOption().getRelativeToOwnerType() != ToastLayoutOption.RelativeToOwnerType.RELATIVE_GLOBAL;
     }
 
-    private boolean isFixedLayout(ToastOption option) {
-        return !option.getLayoutOption().isRelativeToOwner() || option.getLayoutOption().getRelativeToOwnerType() != ToastLayoutOption.RelativeToOwnerType.RELATIVE_CONTAINED;
+    private boolean isFixedLayout(ToastOption option, Component owner) {
+        return !option.getLayoutOption().isRelativeToOwner() || option.getLayoutOption().getRelativeToOwnerType() != ToastLayoutOption.RelativeToOwnerType.RELATIVE_CONTAINED || owner instanceof RootPaneContainer;
     }
 }

--- a/modal-dialog/src/main/java/raven/modal/toast/option/ToastLayoutOption.java
+++ b/modal-dialog/src/main/java/raven/modal/toast/option/ToastLayoutOption.java
@@ -31,6 +31,10 @@ public class ToastLayoutOption {
         return relativeToOwner;
     }
 
+    public boolean isOverflowAlignmentAuto() {
+        return overflowAlignmentAuto;
+    }
+
     public ToastDirection getDirection() {
         if (direction != null) {
             return direction;
@@ -38,12 +42,13 @@ public class ToastLayoutOption {
         return location.getDirection();
     }
 
-    private ToastLayoutOption(ToastLocation location, DynamicSize locationSize, ToastDirection direction, RelativeToOwnerType relativeToOwnerType, boolean relativeToOwner) {
+    private ToastLayoutOption(ToastLocation location, DynamicSize locationSize, ToastDirection direction, RelativeToOwnerType relativeToOwnerType, boolean relativeToOwner, boolean overflowAlignmentAuto) {
         this.location = location;
         this.locationSize = locationSize;
         this.direction = direction;
         this.relativeToOwnerType = relativeToOwnerType;
         this.relativeToOwner = relativeToOwner;
+        this.overflowAlignmentAuto = overflowAlignmentAuto;
     }
 
     public ToastLayoutOption() {
@@ -54,6 +59,7 @@ public class ToastLayoutOption {
     private ToastDirection direction;
     private RelativeToOwnerType relativeToOwnerType = RelativeToOwnerType.RELATIVE_CONTAINED;
     private boolean relativeToOwner;
+    private boolean overflowAlignmentAuto;
     private Insets margin = new Insets(7, 7, 7, 7);
 
     public ToastLayoutOption setLocation(ToastLocation location) {
@@ -82,6 +88,11 @@ public class ToastLayoutOption {
         return this;
     }
 
+    public ToastLayoutOption setOverflowAlignmentAuto(boolean overflowAlignmentAuto) {
+        this.overflowAlignmentAuto = overflowAlignmentAuto;
+        return this;
+    }
+
     public ToastLayoutOption setMargin(int top, int left, int bottom, int right) {
         this.margin = new Insets(top, left, bottom, right);
         return this;
@@ -100,6 +111,7 @@ public class ToastLayoutOption {
         }
         LayoutOption layoutOption = new LayoutOption()
                 .setRelativeToOwner(isRelativeToOwner())
+                .setOverflowAlignmentAuto(overflowAlignmentAuto)
                 .setMargin(insets.top, insets.left, insets.bottom, insets.right)
                 .setAnimateDistance(direction.getValue().getX(), direction.getValue().getY());
 
@@ -122,6 +134,6 @@ public class ToastLayoutOption {
     }
 
     public ToastLayoutOption copy() {
-        return new ToastLayoutOption(location, locationSize, direction, relativeToOwnerType, relativeToOwner);
+        return new ToastLayoutOption(location, locationSize, direction, relativeToOwnerType, relativeToOwner, overflowAlignmentAuto);
     }
 }

--- a/modal-dialog/src/main/java/raven/modal/toast/option/ToastLayoutOption.java
+++ b/modal-dialog/src/main/java/raven/modal/toast/option/ToastLayoutOption.java
@@ -42,13 +42,14 @@ public class ToastLayoutOption {
         return location.getDirection();
     }
 
-    private ToastLayoutOption(ToastLocation location, DynamicSize locationSize, ToastDirection direction, RelativeToOwnerType relativeToOwnerType, boolean relativeToOwner, boolean overflowAlignmentAuto) {
+    private ToastLayoutOption(ToastLocation location, DynamicSize locationSize, ToastDirection direction, RelativeToOwnerType relativeToOwnerType, boolean relativeToOwner, boolean overflowAlignmentAuto, Insets margin) {
         this.location = location;
         this.locationSize = locationSize;
         this.direction = direction;
         this.relativeToOwnerType = relativeToOwnerType;
         this.relativeToOwner = relativeToOwner;
         this.overflowAlignmentAuto = overflowAlignmentAuto;
+        this.margin = margin;
     }
 
     public ToastLayoutOption() {
@@ -134,6 +135,10 @@ public class ToastLayoutOption {
     }
 
     public ToastLayoutOption copy() {
-        return new ToastLayoutOption(location, locationSize, direction, relativeToOwnerType, relativeToOwner, overflowAlignmentAuto);
+        return new ToastLayoutOption(location, locationSize, direction, relativeToOwnerType, relativeToOwner, overflowAlignmentAuto, copyInsets(margin));
+    }
+
+    private Insets copyInsets(Insets insets) {
+        return new Insets(insets.top, insets.left, insets.bottom, insets.right);
     }
 }

--- a/modal-dialog/src/main/java/raven/modal/utils/ModalMouseMovableListener.java
+++ b/modal-dialog/src/main/java/raven/modal/utils/ModalMouseMovableListener.java
@@ -1,0 +1,57 @@
+package raven.modal.utils;
+
+import raven.modal.component.AbstractModalController;
+import raven.modal.component.ModalContainer;
+import raven.modal.option.LayoutOption;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+
+/**
+ * This class for move the modal controller
+ *
+ * @author Raven
+ */
+public class ModalMouseMovableListener extends MouseAdapter {
+
+    private final AbstractModalController modalController;
+    private final LayoutOption layoutOption;
+
+    private Point initialPressed;
+
+    public ModalMouseMovableListener(AbstractModalController modalController) {
+        this.modalController = modalController;
+        this.layoutOption = modalController.getOption().getLayoutOption();
+    }
+
+    @Override
+    public void mousePressed(MouseEvent e) {
+        Insets margin = layoutOption.getMargin();
+        initialPressed = e.getPoint();
+        initialPressed.x += margin.left;
+        initialPressed.y += margin.top;
+        if (layoutOption.isRelativeToOwner()) {
+            ModalContainer container = modalController.getModalContainer();
+            Point point = SwingUtilities.convertPoint(container.getOwner().getParent(), container.getOwner().getLocation(), container);
+            initialPressed.x += point.x;
+            initialPressed.y += point.y;
+        }
+    }
+
+    @Override
+    public void mouseDragged(MouseEvent e) {
+        Point dragged = e.getPoint();
+        Point location = modalController.getLocation();
+        int x = location.x + (dragged.x - initialPressed.x);
+        int y = location.y + (dragged.y - initialPressed.y);
+
+        layoutOption.setLocation(x, y);
+
+        Component parent = modalController.getParent();
+        if (parent != null) {
+            parent.doLayout();
+        }
+    }
+}

--- a/modal-dialog/src/main/java/raven/modal/utils/ModalMouseMovableListener.java
+++ b/modal-dialog/src/main/java/raven/modal/utils/ModalMouseMovableListener.java
@@ -1,5 +1,6 @@
 package raven.modal.utils;
 
+import com.formdev.flatlaf.util.UIScale;
 import raven.modal.component.AbstractModalController;
 import raven.modal.component.ModalContainer;
 import raven.modal.option.LayoutOption;
@@ -19,6 +20,8 @@ public class ModalMouseMovableListener extends MouseAdapter {
     private final AbstractModalController modalController;
     private final LayoutOption layoutOption;
 
+    private DynamicSize initialLocation;
+
     private Point initialPressed;
 
     public ModalMouseMovableListener(AbstractModalController modalController) {
@@ -26,32 +29,85 @@ public class ModalMouseMovableListener extends MouseAdapter {
         this.layoutOption = modalController.getOption().getLayoutOption();
     }
 
+    private float between(float value, float start, float end) {
+        if (value < start) {
+            value = start;
+        } else if (value > end) {
+            value = end;
+        }
+        return value;
+    }
+
+    private boolean isUseOwner() {
+        return layoutOption.isRelativeToOwner() && !(modalController.getModalContainer().getOwner() instanceof RootPaneContainer);
+    }
+
+    private Point getCurrentPoint(Point point) {
+        Insets margin = UIScale.scale(layoutOption.getMargin());
+        point.x += margin.left;
+        point.y += margin.top;
+        if (isUseOwner()) {
+            ModalContainer container = modalController.getModalContainer();
+            Point convertPoint = SwingUtilities.convertPoint(container.getOwner().getParent(), container.getOwner().getLocation(), container);
+            point.x += convertPoint.x;
+            point.y += convertPoint.y;
+        }
+        return point;
+    }
+
     @Override
     public void mousePressed(MouseEvent e) {
-        Insets margin = layoutOption.getMargin();
-        initialPressed = e.getPoint();
-        initialPressed.x += margin.left;
-        initialPressed.y += margin.top;
-        if (layoutOption.isRelativeToOwner()) {
-            ModalContainer container = modalController.getModalContainer();
-            Point point = SwingUtilities.convertPoint(container.getOwner().getParent(), container.getOwner().getLocation(), container);
-            initialPressed.x += point.x;
-            initialPressed.y += point.y;
+        if (SwingUtilities.isLeftMouseButton(e)) {
+            initialLocation = new DynamicSize(layoutOption.getLocation());
+            initialPressed = getCurrentPoint(e.getPoint());
+        }
+    }
+
+    @Override
+    public void mouseReleased(MouseEvent e) {
+        if (SwingUtilities.isLeftMouseButton(e)) {
+            DynamicSize currentLocation = layoutOption.getLocation();
+            boolean doX = currentLocation.getX() != initialLocation.getX() && initialLocation.getX() instanceof Float;
+            boolean doY = currentLocation.getY() != initialLocation.getY() && initialLocation.getY() instanceof Float;
+            if (doX || doY) {
+                Insets margin = UIScale.scale(layoutOption.getMargin());
+                Dimension size = isUseOwner() ? modalController.getModalContainer().getOwner().getSize() : modalController.getModalContainer().getSize();
+                float width = size.width - (margin.left + margin.right);
+                float height = size.height - (margin.top + margin.bottom);
+
+                Number numX = currentLocation.getX();
+                Number numY = currentLocation.getY();
+                if (doX) {
+                    float comWidth = modalController.getWidth() / width / 2f;
+                    numX = between(UIScale.scale(numX.floatValue()) / width + comWidth, 0, 1f);
+                }
+                if (doY) {
+                    float comHeight = modalController.getHeight() / height / 2f;
+                    numY = between(UIScale.scale(numY.floatValue()) / height + comHeight, 0, 1f);
+                }
+                layoutOption.setLocation(numX, numY);
+                Component parent = modalController.getParent();
+                if (parent != null) {
+                    parent.doLayout();
+                }
+            }
         }
     }
 
     @Override
     public void mouseDragged(MouseEvent e) {
-        Point dragged = e.getPoint();
-        Point location = modalController.getLocation();
-        int x = location.x + (dragged.x - initialPressed.x);
-        int y = location.y + (dragged.y - initialPressed.y);
+        if (SwingUtilities.isLeftMouseButton(e)) {
+            Point dragged = e.getPoint();
+            Point location = modalController.getLocation();
+            int x = UIScale.unscale(location.x + (dragged.x - initialPressed.x));
+            int y = UIScale.unscale(location.y + (dragged.y - initialPressed.y));
 
-        layoutOption.setLocation(x, y);
+            layoutOption.setLocation(x, y);
 
-        Component parent = modalController.getParent();
-        if (parent != null) {
-            parent.doLayout();
+            Component parent = modalController.getParent();
+            if (parent != null) {
+                parent.doLayout();
+            }
         }
     }
 }


### PR DESCRIPTION
This PR update

#### Modal and Toast:
- Add new option `overflowAlignmentAuto` work when component overflow the container
    - if `ture` the component adjust to center of container
    - if `false` the location value `<0.5f` adjust to the left, location value `>0.5f` adjust to the right, location
      value `0.5f` adjust center
        - modal: `true` by default
        - toast: `false` by default

``` java
// create option for modal
Option option = ModalDialog.createOption();

option.getLayoutOption()
        .setOverflowAlignmentAuto(false);
```
``` java
// create option for toast
ToastOption option = Toast.createOption();

option.getLayoutOption()
        .setOverflowAlignmentAuto(true);
```


#### Modal:
- Add new layout option `movable` by default `false` if set to true, the modal can move by mouse drag

``` java
// create option
Option option = ModalDialog.createOption();

option.getLayoutOption()
        .setMovable(true);
```
#### Screenshot:
- Toast `overflowAlignmentAuto` default or `false`

`ToastLocation.TOP_TRAILING`

![2025-01-20_234112](https://github.com/user-attachments/assets/0cc0cc87-e7c8-4b12-b588-fb085d86aef2)

`ToastLocation.TOP_LEADING`

![image](https://github.com/user-attachments/assets/5300b37a-d39b-40bd-bc91-1db8d4078cde)

`ToastLocation.TOP_CENTER` or `overflowAlignmentAuto` is `true`

![image](https://github.com/user-attachments/assets/9fa90ddd-1f68-4e4a-bf91-adb831c2c13b)

