### PR TITLE
Toast: add `ToastBorderStyle` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## [2.4.0]-SNAPSHOT
+
+### New features and improvements
+
+- Toast
+    - Add new `ToastBorderStyle`
+        - `borderType` default `BorderType.NONE`
+        - `round` default `10`
+        - `shadowSize` default `insets(0,0,10,10)`
+        - `shadowColor` default `null` (use `Popup.dropShadowColor` as the value)
+        - `shadowOpactity` default `-1` (use `Popup.dropShadowOpacity` as the value)
+        - `lineSize` default `3` (use when`borderType` as `TRAILING_LINE`, `LEADING_LINE`,`TOP_LINE` and `BOTTOM_LINE`)
+        - `borderWidth` default `1` (use when `borderType` as `OUTLINE`)
+        - `padding` default `insets(0,0,0,0)`
+    - Add new layout option `gap` by default `5`
+
+### Changed
+
+- Toast
+    - option `borderType` move from `ToastStyle` to `ToastBorderStyle`
+    - option `lineSize` move from `ToastStyle` to `ToastBorderStyle`
+
+### Demo
+
+- Dashboard form
+    - `TimeSeriesChart` add new `ChartStackedXYBarRenderer`
+
 ## [2.3.0] - 2025-01-21
 
 ### New features and improvements

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Add the snapshot version
 <dependency>
     <groupId>io.github.dj-raven</groupId>
     <artifactId>modal-dialog</artifactId>
-    <version>2.3.0-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.dj-raven</groupId>
         <artifactId>swing-modal-dialog</artifactId>
-        <version>2.3.0</version>
+        <version>2.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>demo</artifactId>

--- a/demo/src/main/java/raven/modal/demo/Demo.java
+++ b/demo/src/main/java/raven/modal/demo/Demo.java
@@ -13,7 +13,7 @@ import java.awt.*;
 
 public class Demo extends JFrame {
 
-    public static final String DEMO_VERSION = "2.3.0";
+    public static final String DEMO_VERSION = "2.4.0-SNAPSHOT";
 
     public Demo() {
         init();

--- a/demo/src/main/java/raven/modal/demo/forms/FormToast.java
+++ b/demo/src/main/java/raven/modal/demo/forms/FormToast.java
@@ -9,6 +9,7 @@ import raven.modal.demo.system.Form;
 import raven.modal.demo.utils.SystemForm;
 import raven.modal.option.Location;
 import raven.modal.toast.ToastPromise;
+import raven.modal.toast.option.ToastBorderStyle;
 import raven.modal.toast.option.ToastLocation;
 import raven.modal.toast.option.ToastOption;
 import raven.modal.toast.option.ToastStyle;
@@ -293,7 +294,7 @@ public class FormToast extends Form {
         Location h = jrLeading.isSelected() ? Location.LEADING : jrTrailing.isSelected() ? Location.TRAILING : Location.CENTER;
         Location v = jrTop.isSelected() ? Location.TOP : Location.BOTTOM;
         ToastStyle.BackgroundType backgroundType = jrBackgroundDefault.isSelected() ? ToastStyle.BackgroundType.DEFAULT : jrBackgroundGradient.isSelected() ? ToastStyle.BackgroundType.GRADIENT : ToastStyle.BackgroundType.NONE;
-        ToastStyle.BorderType borderType = jrBorderOutline.isSelected() ? ToastStyle.BorderType.OUTLINE : jrBorderRightLine.isSelected() ? ToastStyle.BorderType.TRAILING_LINE : jrBorderLeftLine.isSelected() ? ToastStyle.BorderType.LEADING_LINE : jrBorderTopLine.isSelected() ? ToastStyle.BorderType.TOP_LINE : jrBorderBottomLine.isSelected() ? ToastStyle.BorderType.BOTTOM_LINE : ToastStyle.BorderType.NONE;
+        ToastBorderStyle.BorderType borderType = jrBorderOutline.isSelected() ? ToastBorderStyle.BorderType.OUTLINE : jrBorderRightLine.isSelected() ? ToastBorderStyle.BorderType.TRAILING_LINE : jrBorderLeftLine.isSelected() ? ToastBorderStyle.BorderType.LEADING_LINE : jrBorderTopLine.isSelected() ? ToastBorderStyle.BorderType.TOP_LINE : jrBorderBottomLine.isSelected() ? ToastBorderStyle.BorderType.BOTTOM_LINE : ToastBorderStyle.BorderType.NONE;
         option.setAnimationEnabled(chAnimation.isSelected())
                 .setPauseDelayOnHover(chPauseDelayOnHover.isSelected())
                 .setAutoClose(chAutoClose.isSelected())
@@ -304,12 +305,14 @@ public class FormToast extends Form {
                 .setLocation(ToastLocation.from(h, v))
                 .setRelativeToOwner(chRelativeToOwner.isSelected());
         option.getStyle().setBackgroundType(backgroundType)
-                .setBorderType(borderType)
                 .setShowLabel(chShowLabel.isSelected())
                 .setIconSeparateLine(chIconSeparateLine.isSelected())
                 .setShowCloseButton(chShowCloseButton.isSelected())
                 .setPaintTextColor(chPaintTextColor.isSelected())
-                .setPromiseLabel("Saving...");
+                .setPromiseLabel("Saving...")
+                .getBorderStyle()
+                .setBorderType(borderType)
+        ;
         return option;
     }
 

--- a/modal-dialog/pom.xml
+++ b/modal-dialog/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.dj-raven</groupId>
     <artifactId>modal-dialog</artifactId>
-    <version>2.3.0</version>
+    <version>2.4.0-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>

--- a/modal-dialog/src/main/java/raven/modal/component/OutlineBorder.java
+++ b/modal-dialog/src/main/java/raven/modal/component/OutlineBorder.java
@@ -133,4 +133,12 @@ public class OutlineBorder extends FlatEmptyBorder {
     private Color getBackgroundColor() {
         return UIManager.getColor("Panel.background");
     }
+
+    public Insets getShadowSize() {
+        return new Insets(shadowSize.top, shadowSize.left, shadowSize.bottom, shadowSize.right);
+    }
+
+    public float getRound() {
+        return round;
+    }
 }

--- a/modal-dialog/src/main/java/raven/modal/layout/ToastLayout.java
+++ b/modal-dialog/src/main/java/raven/modal/layout/ToastLayout.java
@@ -83,12 +83,13 @@ public class ToastLayout implements LayoutManager {
         }
         boolean isVerticalDirection = layoutOption.getDirection().isVerticalDirection();
         double y;
+        float gap = UIScale.scale((float) layoutOption.getGap()) * previousToast.getAnimate();
         if (layoutOption.getDirection().isToBottomDirection()) {
-            int h = previousToast.getHeight();
+            float h = previousToast.getHeight();
             if (!isVerticalDirection) {
                 h *= previousToast.getAnimate();
             }
-            y = rec.y + previousToast.getY() + h - (baseMargin.top + ly);
+            y = rec.y + previousToast.getY() + h - (baseMargin.top + ly) + gap;
         } else {
             float h;
             if (!isVerticalDirection) {
@@ -96,7 +97,7 @@ public class ToastLayout implements LayoutManager {
             } else {
                 h = rec.height * (animate);
             }
-            y = previousToast.getY() - h;
+            y = previousToast.getY() - h - gap;
         }
         return (int) y;
     }

--- a/modal-dialog/src/main/java/raven/modal/option/BorderOption.java
+++ b/modal-dialog/src/main/java/raven/modal/option/BorderOption.java
@@ -106,8 +106,7 @@ public class BorderOption {
     }
 
     public BorderOption copy() {
-        Insets newShadowSize = new Insets(shadowSize.top, shadowSize.left, shadowSize.bottom, shadowSize.right);
-        return new BorderOption(round, newShadowSize, shadowColor, shadowOpacity, borderWidth, borderColor);
+        return new BorderOption(round, ModalUtils.copyInsets(shadowSize), shadowColor, shadowOpacity, borderWidth, borderColor);
     }
 
     public boolean isBorderAble() {

--- a/modal-dialog/src/main/java/raven/modal/option/LayoutOption.java
+++ b/modal-dialog/src/main/java/raven/modal/option/LayoutOption.java
@@ -1,6 +1,7 @@
 package raven.modal.option;
 
 import raven.modal.utils.DynamicSize;
+import raven.modal.utils.ModalUtils;
 
 import java.awt.*;
 
@@ -128,8 +129,8 @@ public class LayoutOption {
         return this;
     }
 
-    public LayoutOption setBackgroundPadding(int adding) {
-        this.backgroundPadding = new Insets(adding, adding, adding, adding);
+    public LayoutOption setBackgroundPadding(int padding) {
+        this.backgroundPadding = new Insets(padding, padding, padding, padding);
         return this;
     }
 
@@ -186,10 +187,6 @@ public class LayoutOption {
     }
 
     public LayoutOption copy() {
-        return new LayoutOption(horizontalLocation, location, copyInsets(margin), copyInsets(backgroundPadding), new DynamicSize(size), new DynamicSize(animateDistance), relativeToOwnerType, relativeToOwner, overflowAlignmentAuto, movable, animateScale, onTop);
-    }
-
-    private Insets copyInsets(Insets insets) {
-        return new Insets(insets.top, insets.left, insets.bottom, insets.right);
+        return new LayoutOption(horizontalLocation, location, ModalUtils.copyInsets(margin), ModalUtils.copyInsets(backgroundPadding), new DynamicSize(size), new DynamicSize(animateDistance), relativeToOwnerType, relativeToOwner, overflowAlignmentAuto, movable, animateScale, onTop);
     }
 }

--- a/modal-dialog/src/main/java/raven/modal/toast/ToastBorder.java
+++ b/modal-dialog/src/main/java/raven/modal/toast/ToastBorder.java
@@ -1,15 +1,13 @@
 package raven.modal.toast;
 
 import com.formdev.flatlaf.FlatLaf;
-import com.formdev.flatlaf.ui.FlatDropShadowBorder;
-import com.formdev.flatlaf.ui.FlatEmptyBorder;
 import com.formdev.flatlaf.ui.FlatUIUtils;
 import com.formdev.flatlaf.util.ColorFunctions;
 import com.formdev.flatlaf.util.UIScale;
+import raven.modal.component.OutlineBorder;
+import raven.modal.toast.option.ToastBorderStyle;
 import raven.modal.toast.option.ToastStyle;
 
-import javax.swing.*;
-import javax.swing.border.Border;
 import java.awt.*;
 import java.awt.geom.Area;
 import java.awt.geom.Rectangle2D;
@@ -18,27 +16,22 @@ import java.awt.image.BufferedImage;
 /**
  * @author Raven
  */
-class ToastBorder extends FlatEmptyBorder {
+public class ToastBorder extends OutlineBorder {
 
-    private static int SHADOW_SIZE = 10;
-    private Border shadowBorder;
     private Component component;
     private ToastPanel.ToastData toastData;
 
-    protected ToastBorder(Component component, ToastPanel.ToastData toastData) {
-        super(SHADOW_SIZE, SHADOW_SIZE, SHADOW_SIZE, SHADOW_SIZE);
+    public ToastBorder(Component component, ToastPanel.ToastData toastData, Insets shadowSize, float shadowOpacity, Color shadowColor, float round) {
+        super(shadowSize, shadowOpacity, shadowColor, 0, null, round);
         this.component = component;
         this.toastData = toastData;
-        shadowBorder = new FlatDropShadowBorder(
-                UIManager.getColor("Popup.dropShadowColor"), SHADOW_SIZE,
-                FlatUIUtils.getUIFloat("Popup.dropShadowOpacity", 0.5f));
     }
 
     private Insets getStyleBorderInsets(Component c) {
-        ToastStyle style = toastData.getOption().getStyle();
-        if (style.getBorderType() != ToastStyle.BorderType.NONE) {
-            if (style.getBorderType() == ToastStyle.BorderType.OUTLINE) {
-                int line = UIScale.scale(style.getOutlineSize());
+        ToastBorderStyle style = toastData.getOption().getStyle().getBorderStyle();
+        if (style.getBorderType() != ToastBorderStyle.BorderType.NONE) {
+            if (style.getBorderType() == ToastBorderStyle.BorderType.OUTLINE) {
+                int line = UIScale.scale(style.getBorderWidth());
                 return new Insets(line, line, line, line);
             } else {
                 int line = UIScale.scale(style.getLineSize());
@@ -47,11 +40,11 @@ class ToastBorder extends FlatEmptyBorder {
                 int left = 0;
                 int bottom = 0;
                 int right = 0;
-                if ((style.getBorderType() == ToastStyle.BorderType.LEADING_LINE && ltr) || (style.getBorderType() == ToastStyle.BorderType.TRAILING_LINE && !ltr)) {
+                if ((style.getBorderType() == ToastBorderStyle.BorderType.LEADING_LINE && ltr) || (style.getBorderType() == ToastBorderStyle.BorderType.TRAILING_LINE && !ltr)) {
                     left = line;
-                } else if ((style.getBorderType() == ToastStyle.BorderType.TRAILING_LINE && ltr) || (style.getBorderType() == ToastStyle.BorderType.LEADING_LINE && !ltr)) {
+                } else if ((style.getBorderType() == ToastBorderStyle.BorderType.TRAILING_LINE && ltr) || (style.getBorderType() == ToastBorderStyle.BorderType.LEADING_LINE && !ltr)) {
                     right = line;
-                } else if (style.getBorderType() == ToastStyle.BorderType.TOP_LINE) {
+                } else if (style.getBorderType() == ToastBorderStyle.BorderType.TOP_LINE) {
                     top = line;
                 } else {
                     bottom = line;
@@ -72,6 +65,16 @@ class ToastBorder extends FlatEmptyBorder {
         }
     }
 
+    private Insets getInsets(Component c) {
+        Insets insets = getShadowSize();
+        if (!c.getComponentOrientation().isLeftToRight()) {
+            int temp = insets.left;
+            insets.left = insets.right;
+            insets.right = temp;
+        }
+        return UIScale.scale(insets);
+    }
+
     @Override
     public void paintBorder(Component c, Graphics g, int x, int y, int width, int height) {
         Graphics2D g2 = null;
@@ -79,48 +82,49 @@ class ToastBorder extends FlatEmptyBorder {
             BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
             g2 = image.createGraphics();
             FlatUIUtils.setRenderingHints(g2);
-            if (shadowBorder != null) {
-                shadowBorder.paintBorder(c, g2, x, y, width, height);
-            }
-
+            super.paintBorder(c, g2, x, y, width, height);
             ToastStyle style = toastData.getOption().getStyle();
+            ToastBorderStyle borderStyle = style.getBorderStyle();
             boolean ltr = c.getComponentOrientation().isLeftToRight();
-
-            int s = (int) UIScale.scale(SHADOW_SIZE * 0.8f);
-            int bw = width - s * 2;
-            int bh = height - s * 2;
-            float arc = UIScale.scale(SHADOW_SIZE) / 2;
+            Insets insets = getInsets(c);
+            int lx = insets.left;
+            int ly = insets.top;
+            int bw = width - (insets.left + insets.right);
+            int bh = height - (insets.bottom + insets.top);
+            float arc = Math.min(UIScale.scale(getRound()), height) / 2f;
 
             // create background style
             ToastPanel.ThemesData themesData = toastData.getThemes();
             Color defaultColor = Color.decode(FlatLaf.isLafDark() ? themesData.getColors()[1] : themesData.getColors()[0]);
             if (style.getBackgroundType() == ToastStyle.BackgroundType.GRADIENT) {
                 Color color = ColorFunctions.mix(defaultColor, component.getBackground(), 0.3f);
-                g2.setPaint(new GradientPaint(x, y, color, (x + width) * 0.8f, y, component.getBackground()));
+                float start = ltr ? x : (x + width) * 0.8f;
+                float end = ltr ? (x + width) * 0.8f : x;
+                g2.setPaint(new GradientPaint(start, y, color, end, y, component.getBackground()));
             } else {
                 g2.setColor(component.getBackground());
             }
-            Shape shapeBackground = FlatUIUtils.createRoundRectanglePath(s, s, bw, bh, arc, arc, arc, arc);
+            Shape shapeBackground = FlatUIUtils.createRoundRectanglePath(lx, ly, bw, bh, arc, arc, arc, arc);
             g2.fill(shapeBackground);
 
             // create border style
-            if (style.getBorderType() != ToastStyle.BorderType.NONE) {
+            if (borderStyle.getBorderType() != ToastBorderStyle.BorderType.NONE) {
                 Color color = ColorFunctions.mix(defaultColor, component.getBackground(), 0.6f);
                 g2.setColor(color);
-                if (style.getBorderType() == ToastStyle.BorderType.OUTLINE) {
-                    float lineWidth = UIScale.scale(style.getOutlineSize());
-                    g2.fill(FlatUIUtils.createRoundRectangle(s, s, bw, bh, lineWidth, arc, arc, arc, arc));
+                if (borderStyle.getBorderType() == ToastBorderStyle.BorderType.OUTLINE) {
+                    float lineWidth = UIScale.scale(borderStyle.getBorderWidth());
+                    g2.fill(FlatUIUtils.createRoundRectangle(lx, ly, bw, bh, lineWidth, arc, arc, arc, arc));
                 } else {
-                    float lineWidth = UIScale.scale(style.getLineSize());
+                    float lineWidth = UIScale.scale(borderStyle.getLineSize());
                     Area area = new Area(shapeBackground);
-                    if ((style.getBorderType() == ToastStyle.BorderType.LEADING_LINE && ltr) || style.getBorderType() == ToastStyle.BorderType.TRAILING_LINE && !ltr) {
-                        area.intersect(new Area(new Rectangle2D.Float(s, s, lineWidth, bh)));
-                    } else if ((style.getBorderType() == ToastStyle.BorderType.TRAILING_LINE && ltr) || (style.getBorderType() == ToastStyle.BorderType.LEADING_LINE && !ltr)) {
-                        area.intersect(new Area(new Rectangle2D.Float(s + bw - lineWidth, s, lineWidth, bh)));
-                    } else if (style.getBorderType() == ToastStyle.BorderType.TOP_LINE) {
-                        area.intersect(new Area(new Rectangle2D.Float(s, s, bw, lineWidth)));
+                    if ((borderStyle.getBorderType() == ToastBorderStyle.BorderType.LEADING_LINE && ltr) || borderStyle.getBorderType() == ToastBorderStyle.BorderType.TRAILING_LINE && !ltr) {
+                        area.intersect(new Area(new Rectangle2D.Float(lx, ly, lineWidth, bh)));
+                    } else if ((borderStyle.getBorderType() == ToastBorderStyle.BorderType.TRAILING_LINE && ltr) || (borderStyle.getBorderType() == ToastBorderStyle.BorderType.LEADING_LINE && !ltr)) {
+                        area.intersect(new Area(new Rectangle2D.Float(lx + bw - lineWidth, ly, lineWidth, bh)));
+                    } else if (borderStyle.getBorderType() == ToastBorderStyle.BorderType.TOP_LINE) {
+                        area.intersect(new Area(new Rectangle2D.Float(lx, ly, bw, lineWidth)));
                     } else {
-                        area.intersect(new Area(new Rectangle2D.Float(s, s + bh - lineWidth, bw, lineWidth)));
+                        area.intersect(new Area(new Rectangle2D.Float(lx, ly + bh - lineWidth, bw, lineWidth)));
                     }
                     g2.fill(area);
                 }

--- a/modal-dialog/src/main/java/raven/modal/toast/ToastContent.java
+++ b/modal-dialog/src/main/java/raven/modal/toast/ToastContent.java
@@ -32,11 +32,13 @@ class ToastContent extends JComponent {
         try {
             if (toastData.getOption().getStyle().getBackgroundType() == ToastStyle.BackgroundType.GRADIENT) {
                 ToastPanel.ThemesData themesData = toastData.getThemes();
-
+                boolean ltr = getComponentOrientation().isLeftToRight();
                 // gradient paint base on the parent component
                 Rectangle rec = FlatUIUtils.addInsets(new Rectangle(0, 0, getWidth(), getHeight()), parent.getInsets());
                 Color color = ColorFunctions.mix(Color.decode(FlatLaf.isLafDark() ? themesData.getColors()[1] : themesData.getColors()[0]), parent.getBackground(), 0.3f);
-                g2.setPaint(new GradientPaint(rec.x, 0, color, (rec.x + rec.width) * 0.8f, 0, parent.getBackground()));
+                float start = ltr ? rec.x : (rec.x + rec.width) * 0.8f;
+                float end = ltr ? (rec.x + rec.width) * 0.8f : rec.x;
+                g2.setPaint(new GradientPaint(start, 0, color, end, 0, parent.getBackground()));
                 g2.fill(new Rectangle2D.Float(0, 0, getWidth(), getHeight()));
             } else {
                 g2.setColor(parent.getBackground());

--- a/modal-dialog/src/main/java/raven/modal/toast/ToastPanel.java
+++ b/modal-dialog/src/main/java/raven/modal/toast/ToastPanel.java
@@ -75,7 +75,7 @@ public class ToastPanel extends JPanel {
     public void updateUI() {
         super.updateUI();
         if (toastData != null && content != null) {
-            setBorder(new ToastBorder(content, toastData));
+            setBorder(toastData.getOption().getStyle().getBorderStyle().createBorder(content, toastData));
         }
     }
 
@@ -126,13 +126,13 @@ public class ToastPanel extends JPanel {
     }
 
     public ToastPanel createToastCustom(Component component) {
-        content = new ToastContent(new MigLayout(), toastData);
+        content = new ToastContent(new MigLayout(getLayoutInsets()), toastData);
         if (component instanceof ToastCustom) {
             ToastCustom toastCustom = (ToastCustom) component;
             toastCustom.initToastAction(getCustomAction());
         }
         content.add(component);
-        setBorder(new ToastBorder(content, toastData));
+        setBorder(toastData.getOption().getStyle().getBorderStyle().createBorder(content, toastData));
         installStyle(toastData.themes);
         add(content);
         return this;
@@ -171,6 +171,12 @@ public class ToastPanel extends JPanel {
         return promiseCallback;
     }
 
+    private String getLayoutInsets() {
+        Insets padding = toastData.getOption().getStyle().getBorderStyle().getPadding();
+        final int add = 7;
+        return String.format("insets %d %d %d %d", padding.top + add, padding.left + add, padding.bottom + add, padding.right + add);
+    }
+
     private String getLayoutColumn(ThemesData themesData) {
         String columnLayout;
         boolean isShowCloseButton = toastData.getOption().getStyle().isShowCloseButton();
@@ -189,12 +195,12 @@ public class ToastPanel extends JPanel {
     }
 
     private void installDefault(ThemesData themesData) {
-        content = new ToastContent(new MigLayout("filly", getLayoutColumn(themesData), "[center]"), toastData);
+        content = new ToastContent(new MigLayout("filly," + getLayoutInsets(), getLayoutColumn(themesData), "[center]"), toastData);
         content.add(createTextMessage());
         if (toastData.getOption().getStyle().isShowCloseButton()) {
             content.add(createCloseButton());
         }
-        setBorder(new ToastBorder(content, toastData));
+        setBorder(toastData.getOption().getStyle().getBorderStyle().createBorder(content, toastData));
         installStyle(themesData);
         add(content);
     }

--- a/modal-dialog/src/main/java/raven/modal/toast/option/ToastBorderStyle.java
+++ b/modal-dialog/src/main/java/raven/modal/toast/option/ToastBorderStyle.java
@@ -1,0 +1,164 @@
+package raven.modal.toast.option;
+
+import raven.modal.toast.ToastBorder;
+import raven.modal.toast.ToastPanel;
+import raven.modal.utils.ModalUtils;
+
+import javax.swing.border.Border;
+import java.awt.*;
+
+/**
+ * @author Raven
+ */
+public class ToastBorderStyle {
+
+    public static ToastBorderStyle getDefault() {
+        return new ToastBorderStyle();
+    }
+
+    public BorderType getBorderType() {
+        return borderType;
+    }
+
+    public float getRound() {
+        return round;
+    }
+
+    public Insets getShadowSize() {
+        return shadowSize;
+    }
+
+    public Color getShadowColor() {
+        return shadowColor;
+    }
+
+    public float getShadowOpacity() {
+        return shadowOpacity;
+    }
+
+    public int getLineSize() {
+        return lineSize;
+    }
+
+    public int getBorderWidth() {
+        return borderWidth;
+    }
+
+    public Insets getPadding() {
+        return padding;
+    }
+
+    private ToastBorderStyle(BorderType borderType, float round, Insets shadowSize, Color shadowColor, float shadowOpacity, int lineSize, int borderWidth, Insets padding) {
+        this.borderType = borderType;
+        this.round = round;
+        this.shadowSize = shadowSize;
+        this.shadowColor = shadowColor;
+        this.shadowOpacity = shadowOpacity;
+        this.lineSize = lineSize;
+        this.borderWidth = borderWidth;
+        this.padding = padding;
+    }
+
+    public ToastBorderStyle() {
+    }
+
+    private BorderType borderType = BorderType.NONE;
+    private float round = 10;
+    private Insets shadowSize = new Insets(0, 0, 10, 10);
+    private Color shadowColor;
+    private float shadowOpacity = -1;
+    private int lineSize = 3;
+    private int borderWidth = 1;
+    private Insets padding = new Insets(0, 0, 0, 0);
+
+    public ToastBorderStyle setBorderType(BorderType borderType) {
+        this.borderType = borderType;
+        return this;
+    }
+
+    public ToastBorderStyle setRound(float round) {
+        this.round = round;
+        return this;
+    }
+
+    public ToastBorderStyle setShadowSize(int shadowSize) {
+        if (shadowSize < 0) {
+            throw new IllegalArgumentException("shadow size must be >=0");
+        }
+        this.shadowSize = new Insets(shadowSize, shadowSize, shadowSize, shadowSize);
+        return this;
+    }
+
+    public ToastBorderStyle setShadowSize(Insets shadowSize) {
+        if (ModalUtils.minimumInsets(shadowSize) < 0) {
+            throw new IllegalArgumentException("shadow size must be >=0");
+        }
+        this.shadowSize = new Insets(shadowSize.top, shadowSize.left, shadowSize.bottom, shadowSize.right);
+        return this;
+    }
+
+    public ToastBorderStyle setShadowColor(Color shadowColor) {
+        this.shadowColor = shadowColor;
+        return this;
+    }
+
+    public ToastBorderStyle setShadowOpacity(float shadowOpacity) {
+        this.shadowOpacity = shadowOpacity;
+        return this;
+    }
+
+    public ToastBorderStyle setLineSize(int lineSize) {
+        this.lineSize = lineSize;
+        return this;
+    }
+
+    public ToastBorderStyle setBorderWidth(int borderWidth) {
+        this.borderWidth = borderWidth;
+        return this;
+    }
+
+    public ToastBorderStyle setPadding(int top, int left, int bottom, int right) {
+        this.padding = new Insets(top, left, bottom, right);
+        return this;
+    }
+
+    public ToastBorderStyle setPadding(int padding) {
+        this.padding = new Insets(padding, padding, padding, padding);
+        return this;
+    }
+
+    public ToastBorderStyle setShadow(ToastBorderStyle.Shadow shadow) {
+        shadow.apply(this);
+        return this;
+    }
+
+    public Border createBorder(Component component, ToastPanel.ToastData toastData) {
+        return new ToastBorder(component, toastData, shadowSize, shadowOpacity, shadowColor, round);
+    }
+
+    public ToastBorderStyle copy() {
+        return new ToastBorderStyle(borderType, round, ModalUtils.copyInsets(shadowSize), shadowColor, shadowOpacity, lineSize, borderWidth, ModalUtils.copyInsets(padding));
+    }
+
+    public enum Shadow {
+        NONE, SMALL, MEDIUM, LARGE, EXTRA_LARGE;
+
+        private void apply(ToastBorderStyle option) {
+            if (this == NONE) {
+                option.setShadowSize(0);
+            } else if (this == SMALL) {
+                option.setShadowSize(new Insets(0, 0, 6, 6));
+            } else if (this == MEDIUM) {
+                option.setShadowSize(new Insets(0, 0, 10, 10));
+            } else if (this == LARGE) {
+                option.setShadowSize(new Insets(0, 0, 12, 12));
+            } else {
+                option.setShadowSize(new Insets(0, 0, 15, 15));
+            }
+        }
+    }
+
+    public enum BorderType {
+        OUTLINE, TRAILING_LINE, LEADING_LINE, TOP_LINE, BOTTOM_LINE, NONE
+    }
+}

--- a/modal-dialog/src/main/java/raven/modal/toast/option/ToastLayoutOption.java
+++ b/modal-dialog/src/main/java/raven/modal/toast/option/ToastLayoutOption.java
@@ -3,6 +3,7 @@ package raven.modal.toast.option;
 import raven.modal.layout.OptionLayoutUtils;
 import raven.modal.option.LayoutOption;
 import raven.modal.utils.DynamicSize;
+import raven.modal.utils.ModalUtils;
 
 import java.awt.*;
 
@@ -35,6 +36,10 @@ public class ToastLayoutOption {
         return overflowAlignmentAuto;
     }
 
+    public int getGap() {
+        return gap;
+    }
+
     public ToastDirection getDirection() {
         if (direction != null) {
             return direction;
@@ -42,13 +47,14 @@ public class ToastLayoutOption {
         return location.getDirection();
     }
 
-    private ToastLayoutOption(ToastLocation location, DynamicSize locationSize, ToastDirection direction, RelativeToOwnerType relativeToOwnerType, boolean relativeToOwner, boolean overflowAlignmentAuto, Insets margin) {
+    private ToastLayoutOption(ToastLocation location, DynamicSize locationSize, ToastDirection direction, RelativeToOwnerType relativeToOwnerType, boolean relativeToOwner, boolean overflowAlignmentAuto, int gap, Insets margin) {
         this.location = location;
         this.locationSize = locationSize;
         this.direction = direction;
         this.relativeToOwnerType = relativeToOwnerType;
         this.relativeToOwner = relativeToOwner;
         this.overflowAlignmentAuto = overflowAlignmentAuto;
+        this.gap = gap;
         this.margin = margin;
     }
 
@@ -61,6 +67,7 @@ public class ToastLayoutOption {
     private RelativeToOwnerType relativeToOwnerType = RelativeToOwnerType.RELATIVE_CONTAINED;
     private boolean relativeToOwner;
     private boolean overflowAlignmentAuto;
+    private int gap = 5;
     private Insets margin = new Insets(7, 7, 7, 7);
 
     public ToastLayoutOption setLocation(ToastLocation location) {
@@ -91,6 +98,11 @@ public class ToastLayoutOption {
 
     public ToastLayoutOption setOverflowAlignmentAuto(boolean overflowAlignmentAuto) {
         this.overflowAlignmentAuto = overflowAlignmentAuto;
+        return this;
+    }
+
+    public ToastLayoutOption setGap(int gap) {
+        this.gap = gap;
         return this;
     }
 
@@ -135,10 +147,6 @@ public class ToastLayoutOption {
     }
 
     public ToastLayoutOption copy() {
-        return new ToastLayoutOption(location, locationSize, direction, relativeToOwnerType, relativeToOwner, overflowAlignmentAuto, copyInsets(margin));
-    }
-
-    private Insets copyInsets(Insets insets) {
-        return new Insets(insets.top, insets.left, insets.bottom, insets.right);
+        return new ToastLayoutOption(location, locationSize, direction, relativeToOwnerType, relativeToOwner, overflowAlignmentAuto, gap, ModalUtils.copyInsets(margin));
     }
 }

--- a/modal-dialog/src/main/java/raven/modal/toast/option/ToastStyle.java
+++ b/modal-dialog/src/main/java/raven/modal/toast/option/ToastStyle.java
@@ -13,12 +13,12 @@ public class ToastStyle {
         return new ToastStyle();
     }
 
-    public BackgroundType getBackgroundType() {
-        return backgroundType;
+    public ToastBorderStyle getBorderStyle() {
+        return borderStyle;
     }
 
-    public BorderType getBorderType() {
-        return borderType;
+    public BackgroundType getBackgroundType() {
+        return backgroundType;
     }
 
     public boolean isShowLabel() {
@@ -35,10 +35,6 @@ public class ToastStyle {
 
     public boolean isPaintTextColor() {
         return paintTextColor;
-    }
-
-    public int getLineSize() {
-        return lineSize;
     }
 
     public String getPromiseLabel() {
@@ -58,18 +54,13 @@ public class ToastStyle {
         }
     }
 
-    public int getOutlineSize() {
-        return 1;
-    }
-
-    public ToastStyle(BackgroundType backgroundType, BorderType borderType, boolean showLabel, boolean iconSeparateLine, boolean showCloseButton, boolean paintTextColor, int lineSize, String promiseLabel, Icon icon) {
+    private ToastStyle(ToastBorderStyle borderStyle, BackgroundType backgroundType, boolean showLabel, boolean iconSeparateLine, boolean showCloseButton, boolean paintTextColor, String promiseLabel, Icon icon) {
+        this.borderStyle = borderStyle;
         this.backgroundType = backgroundType;
-        this.borderType = borderType;
         this.showLabel = showLabel;
         this.iconSeparateLine = iconSeparateLine;
         this.showCloseButton = showCloseButton;
         this.paintTextColor = paintTextColor;
-        this.lineSize = lineSize;
         this.promiseLabel = promiseLabel;
         this.customIcon = icon;
     }
@@ -77,23 +68,22 @@ public class ToastStyle {
     public ToastStyle() {
     }
 
+    private ToastBorderStyle borderStyle = ToastBorderStyle.getDefault();
     private BackgroundType backgroundType = BackgroundType.DEFAULT;
-    private BorderType borderType = BorderType.NONE;
     private boolean showLabel;
     private boolean iconSeparateLine;
     private boolean showCloseButton = true;
     private boolean paintTextColor;
-    private int lineSize = 3;
     private String promiseLabel = "Loading";
     private Icon customIcon;
 
-    public ToastStyle setBackgroundType(BackgroundType backgroundType) {
-        this.backgroundType = backgroundType;
+    public ToastStyle setBorderStyle(ToastBorderStyle borderStyle) {
+        this.borderStyle = borderStyle;
         return this;
     }
 
-    public ToastStyle setBorderType(BorderType borderType) {
-        this.borderType = borderType;
+    public ToastStyle setBackgroundType(BackgroundType backgroundType) {
+        this.backgroundType = backgroundType;
         return this;
     }
 
@@ -117,11 +107,6 @@ public class ToastStyle {
         return this;
     }
 
-    public ToastStyle setLineSize(int lineSize) {
-        this.lineSize = lineSize;
-        return this;
-    }
-
     public ToastStyle setPromiseLabel(String promiseLabel) {
         this.promiseLabel = promiseLabel;
         return this;
@@ -133,14 +118,10 @@ public class ToastStyle {
     }
 
     public ToastStyle copy() {
-        return new ToastStyle(backgroundType, borderType, showLabel, iconSeparateLine, showCloseButton, paintTextColor, lineSize, promiseLabel, customIcon);
+        return new ToastStyle(borderStyle.copy(), backgroundType, showLabel, iconSeparateLine, showCloseButton, paintTextColor, promiseLabel, customIcon);
     }
 
     public enum BackgroundType {
         DEFAULT, GRADIENT, NONE
-    }
-
-    public enum BorderType {
-        OUTLINE, TRAILING_LINE, LEADING_LINE, TOP_LINE, BOTTOM_LINE, NONE
     }
 }

--- a/modal-dialog/src/main/java/raven/modal/utils/ModalUtils.java
+++ b/modal-dialog/src/main/java/raven/modal/utils/ModalUtils.java
@@ -4,7 +4,6 @@ import com.formdev.flatlaf.FlatClientProperties;
 
 import javax.swing.*;
 import java.awt.*;
-import java.awt.event.WindowStateListener;
 
 /**
  * @author Raven
@@ -23,22 +22,11 @@ public class ModalUtils {
         return Math.min(maxTopBottom, maxLeftRight);
     }
 
-    public static WindowStateListener installWindowStateListener(RootPaneContainer rootPane, WindowStateListener listener) {
-        Window window = SwingUtilities.getWindowAncestor(rootPane.getRootPane());
-        if (window != null) {
-            window.addWindowStateListener(listener);
-        }
-        return listener;
-    }
-
-    public static void uninstallWindowStateListener(RootPaneContainer rootPane, WindowStateListener listener) {
-        Window window = SwingUtilities.getWindowAncestor(rootPane.getRootPane());
-        if (window != null) {
-            window.removeWindowStateListener(listener);
-        }
-    }
-
     public static boolean isFullWindowContent(JRootPane rootPane) {
         return FlatClientProperties.clientPropertyBoolean(rootPane, FlatClientProperties.FULL_WINDOW_CONTENT, false);
+    }
+
+    public static Insets copyInsets(Insets insets) {
+        return new Insets(insets.top, insets.left, insets.bottom, insets.right);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.dj-raven</groupId>
     <artifactId>swing-modal-dialog</artifactId>
-    <version>2.3.0</version>
+    <version>2.4.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <modules>
         <module>modal-dialog</module>


### PR DESCRIPTION
This PR add new `ToastBorderStyle` option and new `gap` layout option

- `ToastBorderStyle`
  - `borderType` default `BorderType.NONE`
  - `round` default `10`
  - `shadowSize` default `insets(0,0,10,10)`
  - `shadowColor` default `null` (use `Popup.dropShadowColor` as the value)
  - `shadowOpactity` default `-1` (use `Popup.dropShadowOpacity` as the value)
  - `lineSize` default `3` (use when`borderType` as `TRAILING_LINE`, `LEADING_LINE`,`TOP_LINE` and `BOTTOM_LINE`)
  - `borderWidth` default `1` (use when `borderType` as `OUTLINE`)
  - `padding` default `insets(0,0,0,0)`
- new `gap` layout option default `5`

#### Example

``` java
Toast.getDefaultOption()
        .getStyle().getBorderStyle()
        .setBorderType(ToastBorderStyle.BorderType.BOTTOM_LINE)
        .setRound(5)
        .setPadding(3)
        .setShadowSize(new Insets(5, 5, 10, 10))
;
```

for shadow we can enum

- `Shadow.NONE`
- `Shadow.SMALL`
- `Shadow.MEDIUM`
- `Shadow.LARGE`
- `Shadow.EXTRA_LARGE`

``` java
Toast.getDefaultOption()
        .getStyle().getBorderStyle()
        .setShadow(ToastBorderStyle.Shadow.LARGE)
;
```

using layout gap

``` java
Toast.getDefaultOption()
        .getLayoutOption()
        .setGap(10)
;
```
