### PR TITLE
HeavyWeight: windows-11 round border

### DIFF
--- a/demo/src/main/java/raven/modal/demo/forms/FormModal.java
+++ b/demo/src/main/java/raven/modal/demo/forms/FormModal.java
@@ -124,6 +124,10 @@ public class FormModal extends Form {
             chScale.setEnabled(chAnimation.isSelected());
         });
 
+        chHeavyWeight.addActionListener(e -> {
+            chShadow.setEnabled(!chHeavyWeight.isSelected());
+        });
+
         chAnimation.setSelected(true);
         chCloseOnPressedEscape.setSelected(true);
         chOpacity.setSelected(true);
@@ -250,7 +254,7 @@ public class FormModal extends Form {
                 .setHeavyWeight(chHeavyWeight.isSelected());
         option.getBorderOption()
                 .setBorderWidth(chBorder.isSelected() ? 1 : 0)
-                .setShadow(chShadow.isSelected() ? BorderOption.Shadow.MEDIUM : BorderOption.Shadow.NONE);
+                .setShadow(chShadow.isSelected() ? BorderOption.Shadow.EXTRA_LARGE : BorderOption.Shadow.NONE);
         option.getLayoutOption().setLocation(h, v)
                 .setRelativeToOwner(chRelativeToOwner.isSelected())
                 .setMovable(chMovable.isSelected());

--- a/modal-dialog/src/main/java/raven/modal/component/HeavyWeightModalController.java
+++ b/modal-dialog/src/main/java/raven/modal/component/HeavyWeightModalController.java
@@ -72,7 +72,6 @@ public class HeavyWeightModalController extends AbstractModalController {
 
     @Override
     protected void onShowing() {
-        installOption();
     }
 
     @Override
@@ -89,6 +88,7 @@ public class HeavyWeightModalController extends AbstractModalController {
 
     public void setModalWindow(ModalWindow modalWindow) {
         this.modalWindow = modalWindow;
+        installOption();
     }
 
     private void installOption() {

--- a/modal-dialog/src/main/java/raven/modal/option/BorderOption.java
+++ b/modal-dialog/src/main/java/raven/modal/option/BorderOption.java
@@ -127,15 +127,15 @@ public class BorderOption {
             if (this == NONE) {
                 option.setShadowSize(0);
             } else if (this == SMALL) {
-                option.setShadowSize(new Insets(4, 4, 6, 6));
+                option.setShadowSize(new Insets(1, 3, 6, 3));
             } else if (this == MEDIUM) {
-                option.setShadowSize(new Insets(8, 8, 12, 12));
+                option.setShadowSize(new Insets(3, 5, 12, 5));
             } else if (this == LARGE) {
-                option.setShadowSize(new Insets(12, 12, 18, 18));
+                option.setShadowSize(new Insets(5, 8, 18, 8));
             } else if (this == EXTRA_LARGE) {
-                option.setShadowSize(new Insets(16, 16, 24, 24));
+                option.setShadowSize(new Insets(7, 12, 24, 12));
             } else {
-                option.setShadowSize(new Insets(20, 20, 30, 30));
+                option.setShadowSize(new Insets(9, 15, 30, 15));
             }
         }
     }

--- a/modal-dialog/src/main/java/raven/modal/option/BorderOption.java
+++ b/modal-dialog/src/main/java/raven/modal/option/BorderOption.java
@@ -127,15 +127,15 @@ public class BorderOption {
             if (this == NONE) {
                 option.setShadowSize(0);
             } else if (this == SMALL) {
-                option.setShadowSize(new Insets(1, 3, 6, 3));
+                option.setShadowSize(new Insets(2, 5, 6, 5));
             } else if (this == MEDIUM) {
-                option.setShadowSize(new Insets(3, 5, 12, 5));
+                option.setShadowSize(new Insets(4, 7, 12, 7));
             } else if (this == LARGE) {
-                option.setShadowSize(new Insets(5, 8, 18, 8));
+                option.setShadowSize(new Insets(6, 9, 18, 9));
             } else if (this == EXTRA_LARGE) {
-                option.setShadowSize(new Insets(7, 12, 24, 12));
+                option.setShadowSize(new Insets(8, 13, 24, 13));
             } else {
-                option.setShadowSize(new Insets(9, 15, 30, 15));
+                option.setShadowSize(new Insets(10, 15, 30, 15));
             }
         }
     }

--- a/modal-dialog/src/main/java/raven/modal/toast/ToastHeavyWeightLayout.java
+++ b/modal-dialog/src/main/java/raven/modal/toast/ToastHeavyWeightLayout.java
@@ -8,6 +8,7 @@ import raven.modal.option.LayoutOption;
 import raven.modal.toast.option.ToastBorderStyle;
 import raven.modal.toast.option.ToastOption;
 import raven.modal.toast.option.ToastStyle;
+import raven.modal.utils.ModalUtils;
 import raven.modal.utils.ModalWindow;
 import raven.modal.utils.ModalWindowBorder;
 
@@ -92,7 +93,8 @@ public class ToastHeavyWeightLayout extends HeavyWeightRelativeLayout {
                 extraY = modalBorderSize.y;
             }
             modal.setBounds(rec.x, ly + y + extraY, width, height);
-            y += rec.height + UIScale.scale(option.getLayoutOption().getGap());
+            int extraGap = ModalUtils.getToastExtraGap(option);
+            y += rec.height + UIScale.scale(option.getLayoutOption().getGap() + extraGap);
             if (isToBottomDirection) {
                 ly += y;
             } else {

--- a/modal-dialog/src/main/java/raven/modal/toast/ToastPanel.java
+++ b/modal-dialog/src/main/java/raven/modal/toast/ToastPanel.java
@@ -93,12 +93,12 @@ public class ToastPanel extends JPanel {
         ToastBorderStyle borderStyle = toastData.getOption().getStyle().getBorderStyle();
         int borderWidth = borderStyle.getBorderType() == ToastBorderStyle.BorderType.OUTLINE ? borderStyle.getBorderWidth() : 0;
         if (getOption().isHeavyWeight()) {
-            if (borderWidth > 0 && ModalUtils.isShadowAndRoundBorderSupport() == false) {
+            if ((borderWidth > 0 && !ModalUtils.isShadowAndRoundBorderSupport()) || borderStyle.getRound() == 0) {
                 // border width painted with round window border
                 // but if windows round border not support we set the border width here
                 setBorder(new CompoundBorder(new ModalLineBorder(borderWidth, toastData.getThemes().getColor(), 0), border));
             } else {
-                setBorder(new ToastBorder(toastData));
+                setBorder(border);
             }
         } else {
             if (FlatUIUtils.isInsetsEmpty(borderStyle.getShadowSize()) && borderStyle.getRound() == 0 && borderWidth == 0) {
@@ -216,7 +216,7 @@ public class ToastPanel extends JPanel {
 
     private String getLayoutInsets() {
         Insets padding = toastData.getOption().getStyle().getBorderStyle().getPadding();
-        final int add = 7;
+        final int add = 7 + ModalUtils.getToastExtraBorderPadding(toastData.getOption());
         return String.format("insets %d %d %d %d", padding.top + add, padding.left + add, padding.bottom + add, padding.right + add);
     }
 

--- a/modal-dialog/src/main/java/raven/modal/toast/option/ToastBorderStyle.java
+++ b/modal-dialog/src/main/java/raven/modal/toast/option/ToastBorderStyle.java
@@ -61,7 +61,7 @@ public class ToastBorderStyle {
 
     private BorderType borderType = BorderType.NONE;
     private int round = 10;
-    private Insets shadowSize = new Insets(0, 0, 10, 10);
+    private Insets shadowSize = new Insets(0, 2, 10, 2);
     private Color shadowColor;
     private float shadowOpacity = -1;
     private int lineSize = 3;
@@ -140,13 +140,13 @@ public class ToastBorderStyle {
             if (this == NONE) {
                 option.setShadowSize(0);
             } else if (this == SMALL) {
-                option.setShadowSize(new Insets(0, 0, 6, 6));
+                option.setShadowSize(new Insets(0, 1, 6, 1));
             } else if (this == MEDIUM) {
-                option.setShadowSize(new Insets(0, 0, 10, 10));
+                option.setShadowSize(new Insets(0, 2, 10, 2));
             } else if (this == LARGE) {
-                option.setShadowSize(new Insets(0, 0, 12, 12));
+                option.setShadowSize(new Insets(0, 3, 14, 3));
             } else {
-                option.setShadowSize(new Insets(0, 0, 15, 15));
+                option.setShadowSize(new Insets(0, 4, 18, 4));
             }
         }
     }

--- a/modal-dialog/src/main/java/raven/modal/utils/ModalUtils.java
+++ b/modal-dialog/src/main/java/raven/modal/utils/ModalUtils.java
@@ -4,6 +4,8 @@ import com.formdev.flatlaf.FlatClientProperties;
 import com.formdev.flatlaf.FlatLaf;
 import com.formdev.flatlaf.util.ColorFunctions;
 import com.formdev.flatlaf.util.SystemInfo;
+import com.formdev.flatlaf.util.UIScale;
+import raven.modal.toast.option.ToastOption;
 
 import javax.swing.*;
 import java.awt.*;
@@ -50,6 +52,22 @@ public class ModalUtils {
     }
 
     public static boolean isShadowAndRoundBorderSupport() {
-        return SystemInfo.isWindows && SystemInfo.isWindows_11_orLater == false;
+        return SystemInfo.isWindows;
+    }
+
+    public static int getToastExtraBorderPadding(ToastOption option) {
+        // extra padding apply when use native border
+        if (!option.isHeavyWeight() || !SystemInfo.isWindows_11_orLater) return 0;
+        int round = UIScale.scale(option.getStyle().getBorderStyle().getRound());
+        if (round <= 0) return 0;
+        return 2;
+    }
+
+    public static int getToastExtraGap(ToastOption option) {
+        // extra gap apply when use native border
+        if (!option.isHeavyWeight() || !SystemInfo.isWindows_11_orLater) return 0;
+        int round = UIScale.scale(option.getStyle().getBorderStyle().getRound());
+        if (round <= 0) return 0;
+        return 10;
     }
 }

--- a/modal-dialog/src/main/java/raven/modal/utils/ModalWindowFactory.java
+++ b/modal-dialog/src/main/java/raven/modal/utils/ModalWindowFactory.java
@@ -131,7 +131,7 @@ public class ModalWindowFactory {
         private final HeavyWeightModalController controller;
 
         public ModalWindowBackground(ModalWindow delegate, HeavyWeightModalController controller) {
-            super(delegate.getOwner(), new ModalBackground(controller), 0, 0);
+            super(delegate.getOwner(), new ModalBackground(controller, delegate.window.getParent()), 0, 0);
             this.delegate = delegate;
             this.controller = controller;
             this.window.setAutoRequestFocus(false);


### PR DESCRIPTION
This PR update heavyWeight windows support round border with drop shadow in windows-11. By using native windows border provide by FlatLaf.
Windows 11 native border support only two corner radiuses `4px` and `8px`:
- 4px if the round border value is 1 to 10
- 8px if the round border values is >10
- option shadow size values not used in native border

#### Modal border round 1 to 10 (4px)
![small](https://github.com/user-attachments/assets/20b51211-9914-48fc-92a9-bf7a01312606)

#### Modal border round >10 (8px)
![big](https://github.com/user-attachments/assets/73c7848a-49a7-41e5-93df-bcf78f69083e)

#### Toast border round 1 to 10 (4px)
![toast-small](https://github.com/user-attachments/assets/106db5fc-71e8-4b4a-8a9f-814043847ac7)

#### Toast border round >10 (8px)
![toast-big](https://github.com/user-attachments/assets/9ed5b89d-d0cb-4146-9386-e13df7648fff)
