### PR TITLE
Fix high DPI scaling on Modal and AvatarIcon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,11 @@
 
 ### Fixed bugs
 
-- Fixed blurry image when high DPI system scaling:
+- Fixed blurry image when high DPI system scaling (issues #36) (PR #37):
     - AvatarIcon
     - DropShadowBorder
     - Modal dialog
+    - ToastBorder
 
 ## [2.5.0] - 2025-05-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 - IntelliJ Themes: removed `Gruvbox Dark Medium` and `Gruvbox Dark Soft` themes, because it unsupported since
   `flatlaf-intellij-themes v3.6`
 
+### Fixed bugs
+
+- Extras
+    - AvatarIcon: fixed blurry image when high DPI system scaling.
+
 ## [2.5.0] - 2025-05-05
 
 ### New features and improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@
 
 ### Fixed bugs
 
-- Extras
-    - AvatarIcon: fixed blurry image when high DPI system scaling.
+- Fixed blurry image when high DPI system scaling:
+    - AvatarIcon
+    - DropShadowBorder
+    - Modal dialog
 
 ## [2.5.0] - 2025-05-05
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Add the snapshot version
 <dependency>
     <groupId>io.github.dj-raven</groupId>
     <artifactId>modal-dialog</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.5.1-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.dj-raven</groupId>
         <artifactId>swing-modal-dialog</artifactId>
-        <version>2.5.0</version>
+        <version>2.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>demo</artifactId>

--- a/demo/src/main/java/raven/modal/demo/Demo.java
+++ b/demo/src/main/java/raven/modal/demo/Demo.java
@@ -14,7 +14,7 @@ import java.awt.*;
 
 public class Demo extends JFrame {
 
-    public static final String DEMO_VERSION = "2.5.0";
+    public static final String DEMO_VERSION = "2.5.1-SNAPSHOT";
 
     public Demo() {
         init();

--- a/demo/src/main/java/raven/modal/demo/forms/other/Card.java
+++ b/demo/src/main/java/raven/modal/demo/forms/other/Card.java
@@ -40,7 +40,7 @@ public class Card extends JPanel {
         JPanel header = new JPanel(new MigLayout("fill,insets 0", "[fill]", "[top]"));
         header.putClientProperty(FlatClientProperties.STYLE, "" +
                 "background:null");
-        JLabel label = new JLabel(new AvatarIcon(employee.getProfile().getIcon(), 130, 130, 20));
+        JLabel label = new JLabel(new AvatarIcon((ImageIcon) employee.getProfile().getIcon(), 130, 130, 20));
         header.add(label);
         return header;
     }

--- a/demo/src/test/java/test/validation/ValidationDrawerBuilder.java
+++ b/demo/src/test/java/test/validation/ValidationDrawerBuilder.java
@@ -42,7 +42,7 @@ public class ValidationDrawerBuilder extends SimpleDrawerBuilder {
 
         if (data.getIcon() instanceof AvatarIcon) {
             AvatarIcon icon = (AvatarIcon) data.getIcon();
-            icon.setIcon(user.getProfile());
+            icon.setIcon((ImageIcon) user.getProfile());
         }
 
         data.setTitle(user.getName())

--- a/modal-dialog/pom.xml
+++ b/modal-dialog/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.dj-raven</groupId>
     <artifactId>modal-dialog</artifactId>
-    <version>2.5.0</version>
+    <version>2.5.1-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>

--- a/modal-dialog/src/main/java/raven/modal/component/DropShadowBorder.java
+++ b/modal-dialog/src/main/java/raven/modal/component/DropShadowBorder.java
@@ -3,6 +3,7 @@ package raven.modal.component;
 import com.formdev.flatlaf.ui.FlatDropShadowBorder;
 import com.formdev.flatlaf.ui.FlatEmptyBorder;
 import com.formdev.flatlaf.ui.FlatUIUtils;
+import com.formdev.flatlaf.util.HiDPIUtils;
 import com.formdev.flatlaf.util.UIScale;
 import raven.modal.utils.ModalUtils;
 
@@ -78,6 +79,11 @@ public class DropShadowBorder extends FlatEmptyBorder {
     public void paintBorder(Component c, Graphics g, int x, int y, int width, int height) {
         Graphics2D g2 = null;
         try {
+            double scale = UIScale.getSystemScaleFactor(c.getGraphicsConfiguration());
+            width = (int) Math.round(width * scale);
+            height = (int) Math.round(height * scale);
+            x = (int) Math.round(x * scale);
+            y = (int) Math.round(y * scale);
             BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
             g2 = image.createGraphics();
             FlatUIUtils.setRenderingHints(g2);
@@ -115,7 +121,14 @@ public class DropShadowBorder extends FlatEmptyBorder {
                 g2.setColor(color);
                 FlatUIUtils.paintOutline(g2, 0, 0, w, h, lineWidth, arc);
             }
-            g.drawImage(image, x, y, null);
+            if (scale > 1) {
+                HiDPIUtils.paintAtScale1x((Graphics2D) g, 0, 0, 100, 100, // width and height are not used
+                        (g2d, x2, y2, width2, height2, scaleFactor2) -> {
+                            g2d.drawImage(image, x2, y2, null);
+                        });
+            } else {
+                g.drawImage(image, x, y, null);
+            }
         } finally {
             if (g2 != null) {
                 g2.dispose();

--- a/modal-dialog/src/main/java/raven/modal/component/DropShadowBorder.java
+++ b/modal-dialog/src/main/java/raven/modal/component/DropShadowBorder.java
@@ -5,6 +5,7 @@ import com.formdev.flatlaf.ui.FlatEmptyBorder;
 import com.formdev.flatlaf.ui.FlatUIUtils;
 import com.formdev.flatlaf.util.HiDPIUtils;
 import com.formdev.flatlaf.util.UIScale;
+import raven.modal.utils.ImageSnapshots;
 import raven.modal.utils.ModalUtils;
 
 import javax.swing.*;
@@ -17,30 +18,30 @@ import java.awt.image.BufferedImage;
 public class DropShadowBorder extends FlatEmptyBorder {
 
     private static final float inner = 0.2f;
-    private final float borderWidth;
+    private final int borderWidth;
 
     private final Insets shadowSize;
-    private final float round;
+    private final int round;
     private final Color borderColor;
     private FlatDropShadowBorder shadowBorder;
 
-    public DropShadowBorder(int shadowSize, float round) {
+    public DropShadowBorder(int shadowSize, int round) {
         this(new Insets(shadowSize, shadowSize, shadowSize, shadowSize), 0, round);
     }
 
-    public DropShadowBorder(Insets shadowSize, float round) {
+    public DropShadowBorder(Insets shadowSize, int round) {
         this(shadowSize, 0, null, round);
     }
 
-    public DropShadowBorder(Insets shadowSize, float borderWidth, float round) {
+    public DropShadowBorder(Insets shadowSize, int borderWidth, int round) {
         this(shadowSize, borderWidth, null, round);
     }
 
-    public DropShadowBorder(Insets shadowSize, float borderWidth, Color borderColor, float round) {
+    public DropShadowBorder(Insets shadowSize, int borderWidth, Color borderColor, int round) {
         this(shadowSize, -1, null, borderWidth, borderColor, round);
     }
 
-    public DropShadowBorder(Insets shadowSize, float shadowOpacity, Color shadowColor, float borderWidth, Color borderColor, float round) {
+    public DropShadowBorder(Insets shadowSize, float shadowOpacity, Color shadowColor, int borderWidth, Color borderColor, int round) {
         super(getShadowInsets(shadowSize, borderWidth, round));
         this.shadowSize = shadowSize;
         this.borderWidth = borderWidth;
@@ -57,7 +58,7 @@ public class DropShadowBorder extends FlatEmptyBorder {
         }
     }
 
-    private static Insets getShadowInsets(Insets shadowInsets, float borderWidth, float round) {
+    private static Insets getShadowInsets(Insets shadowInsets, int borderWidth, int round) {
         float addSize = getBorderWidth(borderWidth, round);
         if (!FlatUIUtils.isInsetsEmpty(shadowInsets)) {
             int top = (int) (shadowInsets.top + addSize);
@@ -70,27 +71,26 @@ public class DropShadowBorder extends FlatEmptyBorder {
         return new Insets(b, b, b, b);
     }
 
-    private static float getBorderWidth(float borderWidth, float round) {
+    private static float getBorderWidth(int borderWidth, int round) {
         float innerArc = round - (borderWidth * 2f);
         return (float) Math.ceil((borderWidth + Math.max((innerArc * inner), 0)));
     }
 
     @Override
     public void paintBorder(Component c, Graphics g, int x, int y, int width, int height) {
-        Graphics2D g2 = null;
+        HiDPIUtils.paintAtScale1x((Graphics2D) g, x, y, width, height, (g2d, x1, y1, w1, h1, scaleFactor) ->
+                paintImpl(c, g2d, x1, y1, w1, h1, scaleFactor));
+    }
+
+    private void paintImpl(Component c, Graphics2D g2d, int x, int y, int width, int height, double scaleFactor) {
+        BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g = image.createGraphics();
         try {
-            double scale = UIScale.getSystemScaleFactor(c.getGraphicsConfiguration());
-            width = (int) Math.round(width * scale);
-            height = (int) Math.round(height * scale);
-            x = (int) Math.round(x * scale);
-            y = (int) Math.round(y * scale);
-            BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
-            g2 = image.createGraphics();
-            FlatUIUtils.setRenderingHints(g2);
+            FlatUIUtils.setRenderingHints(g);
 
             // paint shadow
             if (shadowBorder != null) {
-                shadowBorder.paintBorder(c, g2, 0, 0, width, height);
+                ImageSnapshots.paintBorder(c, shadowBorder, g, 0, 0, c.getWidth(), c.getHeight());
             }
 
             int top = shadowSize.top;
@@ -103,45 +103,39 @@ public class DropShadowBorder extends FlatEmptyBorder {
                 right = shadowSize.left;
             }
 
-            float lineWidth = UIScale.scale(borderWidth);
-            float arc = UIScale.scale(round);
-            float lx = UIScale.scale(left);
-            float ly = UIScale.scale(top);
-            int w = width - UIScale.scale(left + right);
-            int h = height - UIScale.scale(top + bottom);
-            g2.translate(lx, ly);
+            int lineWidth = scale(borderWidth, scaleFactor);
+            int arc = scale(round, scaleFactor);
+            int lx = scale(left, scaleFactor);
+            int ly = scale(top, scaleFactor);
+            int w = width - scale((left + right), scaleFactor);
+            int h = height - scale((top + bottom), scaleFactor);
+            g.translate(lx, ly);
 
             // paint background
-            g2.setColor(c.getBackground());
-            g2.fill(FlatUIUtils.createComponentRectangle(0, 0, w, h, arc));
+            g.setColor(c.getBackground());
+            g.fill(FlatUIUtils.createComponentRectangle(0, 0, w, h, arc));
 
             // paint outline
-            if (borderWidth > 0) {
+            if (lineWidth > 0) {
                 Color color = getBorderColor();
-                g2.setColor(color);
-                FlatUIUtils.paintOutline(g2, 0, 0, w, h, lineWidth, arc);
-            }
-            if (scale > 1) {
-                HiDPIUtils.paintAtScale1x((Graphics2D) g, 0, 0, 100, 100, // width and height are not used
-                        (g2d, x2, y2, width2, height2, scaleFactor2) -> {
-                            g2d.drawImage(image, x2, y2, null);
-                        });
-            } else {
-                g.drawImage(image, x, y, null);
+                g.setColor(color);
+                FlatUIUtils.paintOutline(g, x, y, w, h, lineWidth, arc);
             }
         } finally {
-            if (g2 != null) {
-                g2.dispose();
-            }
+            g.dispose();
         }
+        g2d.drawImage(image, x, y, null);
+    }
+
+    private int scale(int value, double scaleFactor) {
+        return (int) Math.ceil(UIScale.scale(value) * scaleFactor);
     }
 
     protected Color getBorderColor() {
         if (borderColor != null) {
             return borderColor;
         }
-        Color color = UIManager.getColor("Component.borderColor");
-        return color;
+        return UIManager.getColor("Component.borderColor");
     }
 
     public Insets getShadowSize() {

--- a/modal-dialog/src/main/java/raven/modal/utils/ImageSnapshots.java
+++ b/modal-dialog/src/main/java/raven/modal/utils/ImageSnapshots.java
@@ -13,16 +13,33 @@ import java.awt.image.VolatileImage;
  */
 public class ImageSnapshots {
 
-    public static Image createSnapshotsImage(Component component, Component comBorder, Border border) {
+    public static Image createSnapshotsImage(Component component, Component comBorder, Border border, double systemScaleFactor) {
         Image image = createSnapshotsImage(component, 0);
         Insets insets = border.getBorderInsets(comBorder);
         int width = component.getWidth() + insets.left + insets.right;
         int height = component.getHeight() + insets.top + insets.bottom;
-        BufferedImage buffImage = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
-        Graphics2D g2 = buffImage.createGraphics();
-        border.paintBorder(comBorder, g2, 0, 0, comBorder.getWidth(), comBorder.getHeight());
-        g2.drawImage(image, insets.left, insets.top, null);
-        g2.dispose();
+        int x = insets.left;
+        int y = insets.top;
+        BufferedImage buffImage;
+        if (systemScaleFactor > 1) {
+            int imageWidth = (int) Math.round(component.getWidth() * systemScaleFactor);
+            int imageHeight = (int) Math.round(component.getHeight() * systemScaleFactor);
+            width = (int) Math.round(width * systemScaleFactor);
+            height = (int) Math.round(height * systemScaleFactor);
+            x = (int) (x * systemScaleFactor);
+            y = (int) (y * systemScaleFactor);
+            buffImage = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+            Graphics2D g2 = buffImage.createGraphics();
+            border.paintBorder(comBorder, g2, 0, 0, comBorder.getWidth(), comBorder.getHeight());
+            g2.drawImage(image, x, y, imageWidth, imageHeight, null);
+            g2.dispose();
+        } else {
+            buffImage = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+            Graphics2D g2 = buffImage.createGraphics();
+            border.paintBorder(comBorder, g2, 0, 0, comBorder.getWidth(), comBorder.getHeight());
+            g2.drawImage(image, x, y, null);
+            g2.dispose();
+        }
         return buffImage;
     }
 

--- a/modal-dialog/src/main/java/raven/modal/utils/ImageSnapshots.java
+++ b/modal-dialog/src/main/java/raven/modal/utils/ImageSnapshots.java
@@ -30,7 +30,8 @@ public class ImageSnapshots {
             y = (int) (y * systemScaleFactor);
             buffImage = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
             Graphics2D g2 = buffImage.createGraphics();
-            border.paintBorder(comBorder, g2, 0, 0, comBorder.getWidth(), comBorder.getHeight());
+
+            paintBorder(comBorder, border, g2, 0, 0, comBorder.getWidth(), comBorder.getHeight());
             g2.drawImage(image, x, y, imageWidth, imageHeight, null);
             g2.dispose();
         } else {
@@ -41,6 +42,16 @@ public class ImageSnapshots {
             g2.dispose();
         }
         return buffImage;
+    }
+
+    public static void paintBorder(Component com, Border border, Graphics g, int x, int y, int width, int height) {
+        Graphics2D g2 = (Graphics2D) g.create();
+        try {
+            g2.setTransform(com.getGraphicsConfiguration().getDefaultTransform());
+            border.paintBorder(com, g2, x, y, width, height);
+        } finally {
+            g2.dispose();
+        }
     }
 
     public static Image createSnapshotsImage(Component component, float round) {

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.dj-raven</groupId>
     <artifactId>swing-modal-dialog</artifactId>
-    <version>2.5.0</version>
+    <version>2.5.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <modules>
         <module>modal-dialog</module>


### PR DESCRIPTION
This PR fixed blurry image when high DPI system scaling on:
- AvatarIcon
- DropShadowBorder
- Modal dialog

See (issue #36)

## Screenshot

#### Before (scale 125%)

![image](https://github.com/user-attachments/assets/7a4cc1eb-3c81-4400-8c35-50a000682f15)

![image](https://github.com/user-attachments/assets/9ab38e94-8e0e-4827-8108-29ff054355d3)


#### After fixed (scale 125%)

![image](https://github.com/user-attachments/assets/cc377c4f-afa0-49a7-b291-648f1daecbfa)

![image](https://github.com/user-attachments/assets/8584b388-57a3-48ef-bd97-56388e775e6c)

## Still in Issues

This PR won't fix the issue when create the image snapshots. the image snapshots was create when modal is showing with animation or menu drawer is showing with animation.

#### Demo in FlatLaf (scale 125%)
https://github.com/user-attachments/assets/6a29b8f5-8bdd-4abc-88f6-01df7e6f709f

#### Modal Dialog (scale 125%)

https://github.com/user-attachments/assets/c3976f37-d83d-497a-9e5d-2e468eb5db5a

