### PR TITLE
HeavyWeight: macOS round border

### DIFF
--- a/modal-dialog/src/main/java/raven/modal/component/ModalBackground.java
+++ b/modal-dialog/src/main/java/raven/modal/component/ModalBackground.java
@@ -98,7 +98,7 @@ public class ModalBackground extends JComponent {
     }
 
     private int getWindowRoundBorder() {
-        if (SystemInfo.isWindows_11_orLater && !isWindowMaximized()) {
+        if ((SystemInfo.isWindows_11_orLater || SystemInfo.isMacOS) && !isWindowMaximized()) {
             return 8;
         }
         return 0;

--- a/modal-dialog/src/main/java/raven/modal/utils/ModalUtils.java
+++ b/modal-dialog/src/main/java/raven/modal/utils/ModalUtils.java
@@ -52,12 +52,12 @@ public class ModalUtils {
     }
 
     public static boolean isShadowAndRoundBorderSupport() {
-        return SystemInfo.isWindows;
+        return SystemInfo.isWindows || SystemInfo.isMacOS;
     }
 
     public static int getToastExtraBorderPadding(ToastOption option) {
         // extra padding apply when use native border
-        if (!option.isHeavyWeight() || !SystemInfo.isWindows_11_orLater) return 0;
+        if (!option.isHeavyWeight() || !(SystemInfo.isWindows_11_orLater || SystemInfo.isMacOS)) return 0;
         int round = UIScale.scale(option.getStyle().getBorderStyle().getRound());
         if (round <= 0) return 0;
         return 2;
@@ -65,7 +65,7 @@ public class ModalUtils {
 
     public static int getToastExtraGap(ToastOption option) {
         // extra gap apply when use native border
-        if (!option.isHeavyWeight() || !SystemInfo.isWindows_11_orLater) return 0;
+        if (!option.isHeavyWeight() || !(SystemInfo.isWindows_11_orLater || SystemInfo.isMacOS)) return 0;
         int round = UIScale.scale(option.getStyle().getBorderStyle().getRound());
         if (round <= 0) return 0;
         return 10;

--- a/modal-dialog/src/main/java/raven/modal/utils/ModalWindowFactory.java
+++ b/modal-dialog/src/main/java/raven/modal/utils/ModalWindowFactory.java
@@ -1,5 +1,6 @@
 package raven.modal.utils;
 
+import com.formdev.flatlaf.ui.FlatNativeMacLibrary;
 import com.formdev.flatlaf.ui.FlatNativeWindowsLibrary;
 import com.formdev.flatlaf.util.SystemInfo;
 import com.formdev.flatlaf.util.UIScale;
@@ -46,6 +47,14 @@ public class ModalWindowFactory {
             return new ModalWindow(owner, contents, x, y);
         }
 
+        if (SystemInfo.isMacOS && isMacOSBorderSupported()) {
+            ModalWindow modalWindow = new ModalWindow(owner, contents, x, y);
+            if (border.getRound() > 0) {
+                setupRoundBorder(modalWindow.window, border);
+            }
+            return modalWindow;
+        }
+
         if (isWindows11BorderSupported()) {
             ModalWindow modalWindow = new ModalWindow(owner, contents, x, y);
             if (border.getRound() > 0) {
@@ -65,8 +74,6 @@ public class ModalWindowFactory {
     }
 
     private boolean isShadowAndRoundBorderSupport() {
-        // for mac-os and linux not yet test
-        // we can use native border provide by flatlaf (next update)
         return ModalUtils.isShadowAndRoundBorderSupport();
     }
 
@@ -74,9 +81,13 @@ public class ModalWindowFactory {
         return SystemInfo.isWindows_11_orLater && FlatNativeWindowsLibrary.isLoaded();
     }
 
+    private boolean isMacOSBorderSupported() {
+        return SystemInfo.isMacOS && FlatNativeMacLibrary.isLoaded();
+    }
+
     private void setupRoundBorder(Window window, ModalWindowBorder border) {
-        int borderCornerRadius = UIScale.scale(border.getRound());
-        int borderWidth = UIScale.scale(border.getBorderWidth());
+        int borderCornerRadius = border.getRound();
+        int borderWidth = border.getBorderWidth();
         Color borderColor;
 
         if (borderWidth > 0) {
@@ -113,6 +124,8 @@ public class ModalWindowFactory {
 
             // set border color
             FlatNativeWindowsLibrary.dwmSetWindowAttributeCOLORREF(hwnd, FlatNativeWindowsLibrary.DWMWA_BORDER_COLOR, borderColor);
+        } else if (SystemInfo.isMacOS) {
+            FlatNativeMacLibrary.setWindowRoundedBorder(window, borderCornerRadius, borderWidth, borderColor != null ? borderColor.getRGB() : 0);
         }
     }
 


### PR DESCRIPTION
This PR update heavyWeight windows support round border in macOS By using native windows border provide by FlatLaf. Implemented both toast and modal.