### PR TITLE
Toast HeavyWeight: fixed layout when location was set to bottom

### DIFF
--- a/modal-dialog/src/main/java/raven/modal/toast/ToastHeavyWeightLayout.java
+++ b/modal-dialog/src/main/java/raven/modal/toast/ToastHeavyWeightLayout.java
@@ -92,13 +92,14 @@ public class ToastHeavyWeightLayout extends HeavyWeightRelativeLayout {
                 rec.x += modalBorderSize.x;
                 extraY = modalBorderSize.y;
             }
-            modal.setBounds(rec.x, ly + y + extraY, width, height);
             int extraGap = ModalUtils.getToastExtraGap(option);
-            y += rec.height + UIScale.scale(option.getLayoutOption().getGap() + extraGap);
+            int addHeight = rec.height + UIScale.scale(option.getLayoutOption().getGap() + extraGap);
+            if (!isToBottomDirection && i > 0) {
+                ly -= addHeight;
+            }
+            modal.setBounds(rec.x, ly + y + extraY, width, height);
             if (isToBottomDirection) {
-                ly += y;
-            } else {
-                ly -= y;
+                ly += addHeight;
             }
         }
     }


### PR DESCRIPTION
This PR fixed toast heavyWeight when location was set to bottom.

![2025-08-07_181048](https://github.com/user-attachments/assets/16ca45e6-b030-47d6-bb74-58cd94fa881c)
