### PR TITLE
Toast: add unique ID

### DIFF
--- a/demo/src/test/java/test/TestToast.java
+++ b/demo/src/test/java/test/TestToast.java
@@ -31,8 +31,8 @@ public class TestToast extends BaseFrame {
                     .setShowLabel(true)
                     .setIconSeparateLine(true)
                     .getBorderStyle().setBorderType(ToastBorderStyle.BorderType.LEADING_LINE);
-
-            Toast.show(this, Toast.Type.INFO, "The operation was completed successfully without any issues.", toastOption);
+            String id = Toast.show(this, Toast.Type.INFO, "The operation was completed successfully without any issues.", toastOption);
+            System.out.println("id:" + id);
         });
         add(cmdShow);
         html();

--- a/modal-dialog/src/main/java/raven/modal/Toast.java
+++ b/modal-dialog/src/main/java/raven/modal/Toast.java
@@ -10,6 +10,7 @@ import javax.swing.*;
 import java.awt.*;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * @author Raven
@@ -17,6 +18,7 @@ import java.util.Map;
 public class Toast {
 
     private static Toast instance;
+    private static final AtomicInteger toastCounter = new AtomicInteger();
     private final Integer LAYER = JLayeredPane.POPUP_LAYER;
     private final Map<RootPaneContainer, ToastContainerLayer> map;
     private final Map<Type, ToastPanel.ThemesData> themesDataMap;
@@ -45,59 +47,60 @@ public class Toast {
         themesDataMap.put(Type.DEFAULT, new ToastPanel.ThemesData(null, new String[]{"#64748b", "#64748b"}));
     }
 
-    public static void show(Component owner, Type type, String message) {
-        show(owner, type, message, getDefaultOption());
+    public static String show(Component owner, Type type, String message) {
+        return show(owner, type, message, getDefaultOption());
     }
 
-    public static void show(Component owner, Type type, String message, ToastLocation location) {
+    public static String show(Component owner, Type type, String message, ToastLocation location) {
         ToastOption option = createOption();
         option.getLayoutOption()
                 .setLocation(location);
-        show(owner, type, message, option);
+        return show(owner, type, message, option);
     }
 
-    public static void show(Component owner, Type type, String message, ToastLocation location, ToastOption option) {
+    public static String show(Component owner, Type type, String message, ToastLocation location, ToastOption option) {
         option.getLayoutOption()
                 .setLocation(location);
-        show(owner, type, message, option, null);
+        return show(owner, type, message, option, null);
     }
 
-    public static void show(Component owner, Type type, String message, ToastOption option) {
-        show(owner, type, message, option, null);
+    public static String show(Component owner, Type type, String message, ToastOption option) {
+        return show(owner, type, message, option, null);
     }
 
-    public static void showPromise(Component owner, String message, ToastPromise promise) {
-        showPromise(owner, message, getDefaultOption(), promise);
+    public static String showPromise(Component owner, String message, ToastPromise promise) {
+        return showPromise(owner, message, getDefaultOption(), promise);
     }
 
-    public static void showPromise(Component owner, String message, ToastLocation location, ToastPromise promise) {
+    public static String showPromise(Component owner, String message, ToastLocation location, ToastPromise promise) {
         ToastOption option = createOption();
         option.getLayoutOption()
                 .setLocation(location);
-        showPromise(owner, message, option, promise);
+        return showPromise(owner, message, option, promise);
     }
 
-    public static void showPromise(Component owner, String message, ToastLocation location, ToastOption option, ToastPromise promise) {
+    public static String showPromise(Component owner, String message, ToastLocation location, ToastOption option, ToastPromise promise) {
         option.getLayoutOption()
                 .setLocation(location);
-        showPromise(owner, message, option, promise);
+        return showPromise(owner, message, option, promise);
     }
 
-    public static void showPromise(Component owner, String message, ToastOption option, ToastPromise promise) {
-        show(owner, null, message, option, promise);
+    public static String showPromise(Component owner, String message, ToastOption option, ToastPromise promise) {
+        return show(owner, null, message, option, promise);
     }
 
-    public static void showCustom(Component owner, Component component, ToastOption option) {
-        show(owner, null, component, option, null);
+    public static String showCustom(Component owner, Component component, ToastOption option) {
+        return show(owner, null, component, option, null);
     }
 
-    private static void show(Component owner, Type type, Object object, ToastOption option, ToastPromise promise) {
+    private static String show(Component owner, Type type, Object object, ToastOption option, ToastPromise promise) {
         ToastPanel.ThemesData themesData = getInstance().themesDataMap.get(type);
         RootPaneContainer rootPaneContainer = ModalDialog.getRootPaneContainer(owner);
         BaseToastContainer toastContainerLayer = getInstance().getToastContainer(owner, option.isHeavyWeight());
         String message = object instanceof String ? object.toString() : null;
         Component toastOwner = option.getLayoutOption().isRelativeToOwner() ? owner : null;
-        ToastPanel toastPanel = new ToastPanel(toastContainerLayer, toastOwner, new ToastPanel.ToastData(type, option, themesData, message));
+        String toastId = nextToastId();
+        ToastPanel toastPanel = new ToastPanel(toastContainerLayer, toastOwner, new ToastPanel.ToastData(type, option, themesData, message), toastId);
         if (object instanceof Component) {
             toastContainerLayer.add(toastPanel.createToastCustom((Component) object));
         } else if (promise != null) {
@@ -109,6 +112,7 @@ public class Toast {
             toastPanel.applyComponentOrientation(rootPaneContainer.getRootPane().getComponentOrientation());
         }
         toastPanel.start();
+        return toastId;
     }
 
     public static boolean checkPromiseId(String id) {
@@ -121,6 +125,18 @@ public class Toast {
             }
         }
         return ToastHeavyWeight.getInstance().checkPromiseId(id);
+    }
+
+    public static boolean isIdExist(String id) {
+        if (id == null) {
+            throw new IllegalArgumentException("id must not null");
+        }
+        for (BaseToastContainer com : getInstance().map.values()) {
+            if (com.checkId(id)) {
+                return true;
+            }
+        }
+        return ToastHeavyWeight.getInstance().isIdExist(id);
     }
 
     public static void closeAll() {
@@ -137,11 +153,29 @@ public class Toast {
         ToastHeavyWeight.getInstance().closeAll(location);
     }
 
+    public static void close(String id) {
+        for (BaseToastContainer com : getInstance().map.values()) {
+            if (com.close(id)) {
+                return;
+            }
+        }
+        ToastHeavyWeight.getInstance().close(id);
+    }
+
     public static void closeAllImmediately() {
         getInstance().map.values().forEach(com -> {
             com.closeAllImmediately();
         });
         ToastHeavyWeight.getInstance().closeAllImmediately();
+    }
+
+    public static void closeImmediately(String id) {
+        for (BaseToastContainer com : getInstance().map.values()) {
+            if (com.closeImmediately(id)) {
+                return;
+            }
+        }
+        ToastHeavyWeight.getInstance().closeImmediately(id);
     }
 
     public static void setReverseOrder(boolean reverseOrder) {
@@ -224,6 +258,10 @@ public class Toast {
             return ToastHeavyWeight.getInstance().getToastHeavyWeightContainer(owner);
         }
         return getToastContainerLayered(ModalDialog.getRootPaneContainer(owner));
+    }
+
+    private static String nextToastId() {
+        return "toast-" + toastCounter.incrementAndGet();
     }
 
     public static void setEnableHierarchy(boolean enable) {

--- a/modal-dialog/src/main/java/raven/modal/toast/AbstractToastContainerLayer.java
+++ b/modal-dialog/src/main/java/raven/modal/toast/AbstractToastContainerLayer.java
@@ -63,6 +63,20 @@ public abstract class AbstractToastContainerLayer extends AbstractRelativeContai
     }
 
     @Override
+    public boolean close(String id) {
+        synchronized (toastPanels) {
+            for (int i = 0; i < toastPanels.size(); i++) {
+                ToastPanel toastPanel = toastPanels.get(i);
+                if (id.equals(toastPanel.getId())) {
+                    toastPanel.stop();
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
     public void closeAllImmediately() {
         synchronized (toastPanels) {
             for (int i = toastPanels.size() - 1; i >= 0; i--) {
@@ -70,6 +84,20 @@ public abstract class AbstractToastContainerLayer extends AbstractRelativeContai
                 p.close();
             }
         }
+    }
+
+    @Override
+    public boolean closeImmediately(String id) {
+        synchronized (toastPanels) {
+            for (int i = 0; i < toastPanels.size(); i++) {
+                ToastPanel p = toastPanels.get(i);
+                if (id.equals(p.getId())) {
+                    p.close();
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     @Override
@@ -90,6 +118,19 @@ public abstract class AbstractToastContainerLayer extends AbstractRelativeContai
             for (int i = toastPanels.size() - 1; i >= 0; i--) {
                 ToastPanel p = toastPanels.get(i);
                 if (p.checkPromiseId(id)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+    @Override
+    public boolean checkId(String id) {
+        synchronized (toastPanels) {
+            for (int i = toastPanels.size() - 1; i >= 0; i--) {
+                ToastPanel p = toastPanels.get(i);
+                if (id.equals(p.getId())) {
                     return true;
                 }
             }

--- a/modal-dialog/src/main/java/raven/modal/toast/BaseToastContainer.java
+++ b/modal-dialog/src/main/java/raven/modal/toast/BaseToastContainer.java
@@ -17,9 +17,15 @@ public interface BaseToastContainer {
 
     void closeAllImmediately();
 
+    boolean close(String id);
+
+    boolean closeImmediately(String id);
+
     void closeAll(ToastLocation location);
 
     boolean checkPromiseId(String id);
+
+    boolean checkId(String id);
 
     void updateLayout();
 

--- a/modal-dialog/src/main/java/raven/modal/toast/ToastHeavyWeight.java
+++ b/modal-dialog/src/main/java/raven/modal/toast/ToastHeavyWeight.java
@@ -41,6 +41,15 @@ public class ToastHeavyWeight {
         return false;
     }
 
+    public boolean isIdExist(String id) {
+        for (ToastHeavyWeightContainerLayer com : map.values()) {
+            if (com.checkId(id)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public void closeAll() {
         map.values().forEach(con -> {
             con.closeAll();
@@ -53,10 +62,26 @@ public class ToastHeavyWeight {
         });
     }
 
+    public void close(String id) {
+        for (ToastHeavyWeightContainerLayer com : map.values()) {
+            if (com.close(id)) {
+                return;
+            }
+        }
+    }
+
     public void closeAllImmediately() {
         map.values().forEach(con -> {
             con.closeAllImmediately();
         });
+    }
+
+    public void closeImmediately(String id) {
+        for (ToastHeavyWeightContainerLayer com : map.values()) {
+            if (com.closeImmediately(id)) {
+                return;
+            }
+        }
     }
 
     public ToastHeavyWeightContainerLayer getToastHeavyWeightContainer(Component owner) {

--- a/modal-dialog/src/main/java/raven/modal/toast/ToastHeavyWeightContainerLayer.java
+++ b/modal-dialog/src/main/java/raven/modal/toast/ToastHeavyWeightContainerLayer.java
@@ -67,6 +67,19 @@ public class ToastHeavyWeightContainerLayer implements BaseToastContainer {
     }
 
     @Override
+    public boolean close(String id) {
+        for (int i = 0; i < listToastHeavyWeight.size(); i++) {
+            ToastHeavyWeightLayout toastLayout = listToastHeavyWeight.get(i);
+            if (toastLayout != null) {
+                if (close(toastLayout, id)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
     public void closeAllImmediately() {
         for (int i = listToastHeavyWeight.size() - 1; i >= 0; i--) {
             ToastHeavyWeightLayout toastLayout = listToastHeavyWeight.get(i);
@@ -74,6 +87,19 @@ public class ToastHeavyWeightContainerLayer implements BaseToastContainer {
                 closeAllImmediately(toastLayout);
             }
         }
+    }
+
+    @Override
+    public boolean closeImmediately(String id) {
+        for (int i = 0; i < listToastHeavyWeight.size(); i++) {
+            ToastHeavyWeightLayout toastLayout = listToastHeavyWeight.get(i);
+            if (toastLayout != null) {
+                if (closeImmediately(toastLayout, id)) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     @Override
@@ -94,6 +120,21 @@ public class ToastHeavyWeightContainerLayer implements BaseToastContainer {
             for (int j = 0; j < list.size(); j++) {
                 ToastPanel toastPanel = (ToastPanel) list.get(j).getContents();
                 if (toastPanel.checkPromiseId(id)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean checkId(String id) {
+        for (int i = 0; i < listToastHeavyWeight.size(); i++) {
+            ToastHeavyWeightLayout toastLayout = listToastHeavyWeight.get(i);
+            List<ModalWindow> list = toastLayout.getModalWindows();
+            for (int j = 0; j < list.size(); j++) {
+                ToastPanel toastPanel = (ToastPanel) list.get(j).getContents();
+                if (id.equals(toastPanel.getId())) {
                     return true;
                 }
             }
@@ -125,11 +166,35 @@ public class ToastHeavyWeightContainerLayer implements BaseToastContainer {
         }
     }
 
+    private boolean close(HeavyWeightRelativeLayout heavyWeight, String id) {
+        List<ModalWindow> modalWindows = heavyWeight.getModalWindows();
+        for (int i = modalWindows.size() - 1; i >= 0; i--) {
+            ToastPanel toastPanel = (ToastPanel) modalWindows.get(i).getContents();
+            if (id.equals(toastPanel.getId())) {
+                toastPanel.stop();
+                return true;
+            }
+        }
+        return false;
+    }
+
     private void closeAllImmediately(HeavyWeightRelativeLayout heavyWeight) {
         List<ModalWindow> modalWindows = heavyWeight.getModalWindows();
         for (int i = modalWindows.size() - 1; i >= 0; i--) {
             ((ToastPanel) modalWindows.get(i).getContents()).close();
         }
+    }
+
+    private boolean closeImmediately(HeavyWeightRelativeLayout heavyWeight, String id) {
+        List<ModalWindow> modalWindows = heavyWeight.getModalWindows();
+        for (int i = modalWindows.size() - 1; i >= 0; i--) {
+            ToastPanel toastPanel = (ToastPanel) modalWindows.get(i).getContents();
+            if (id.equals(toastPanel.getId())) {
+                toastPanel.close();
+                return true;
+            }
+        }
+        return false;
     }
 
     private void closeAll(HeavyWeightRelativeLayout heavyWeight, ToastLocation location) {

--- a/modal-dialog/src/main/java/raven/modal/toast/ToastPanel.java
+++ b/modal-dialog/src/main/java/raven/modal/toast/ToastPanel.java
@@ -49,9 +49,14 @@ public class ToastPanel extends JPanel {
         return toastData.getOption();
     }
 
+    public String getId() {
+        return id;
+    }
+
     private final BaseToastContainer baseToastContainer;
     private final Component owner;
     private ToastData toastData;
+    private String id;
     private ToastContent content;
     private TextMessage textMessage;
     private JLabel labelTitle;
@@ -69,10 +74,11 @@ public class ToastPanel extends JPanel {
     private boolean available = true;
     private Image snapshotContent;
 
-    public ToastPanel(BaseToastContainer baseToastContainer, Component owner, ToastData toastData) {
+    public ToastPanel(BaseToastContainer baseToastContainer, Component owner, ToastData toastData, String id) {
         this.baseToastContainer = baseToastContainer;
         this.owner = owner;
         this.toastData = toastData;
+        this.id = id;
         init();
     }
 
@@ -519,8 +525,10 @@ public class ToastPanel extends JPanel {
             }
             showing = false;
             animator.start();
+            id = null;
         } else {
             showing = false;
+            id = null;
             removeToast();
         }
     }


### PR DESCRIPTION
When showing a toast, it now returns a unique toast ID. Each toast is automatically assigned an ID when displayed.
- Format: `toast-{toast_count}`
- Example: `toast-1`, `toast-2`

#### Example
``` java
String id = Toast.show(this, Toast.Type.INFO, "Hello.");
```
New static method added:
```java
boolean isToastAvailable(String id)
void close(String id)
void closeImmediately(String id)
```